### PR TITLE
Minor QoL Features

### DIFF
--- a/src/init_save.c
+++ b/src/init_save.c
@@ -349,6 +349,11 @@ RECOMP_PATCH void Sram_SaveEndOfCycle(PlayState* play) {
         //Inventory_DeleteItem(ITEM_MASK_FIERCE_DEITY, SLOT(ITEM_MASK_FIERCE_DEITY));
     }
 
+    // add chateau back into inventory if used this cycle
+    if (CHECK_WEEKEVENTREG(WEEKEVENTREG_DRANK_CHATEAU_ROMANI)) {
+        gSaveContext.save.saveInfo.inventory.items[SLOT_BOTTLE_1] = ITEM_CHATEAU;
+    }
+
     for (i = 0; i < ARRAY_COUNT(sPersistentCycleWeekEventRegs); i++) {
         u16 isPersistentBits = sPersistentCycleWeekEventRegs[i];
 

--- a/src/init_save.c
+++ b/src/init_save.c
@@ -95,6 +95,7 @@ RECOMP_PATCH void Sram_InitDebugSave(void) {
     gSaveContext.save.hasTatl = true;
 
     // start with basic consumables
+    gSaveContext.save.saveInfo.playerData.rupees = 99;
     gSaveContext.save.saveInfo.inventory.items[SLOT_DEKU_STICK] = ITEM_DEKU_STICK;
     gSaveContext.save.saveInfo.inventory.ammo[SLOT_DEKU_STICK] = 10;
     gSaveContext.save.saveInfo.inventory.items[SLOT_DEKU_NUT] = ITEM_DEKU_NUT;

--- a/src/init_save.c
+++ b/src/init_save.c
@@ -94,6 +94,12 @@ RECOMP_PATCH void Sram_InitDebugSave(void) {
 
     gSaveContext.save.hasTatl = true;
 
+    // start with basic consumables
+    gSaveContext.save.saveInfo.inventory.items[SLOT_DEKU_STICK] = ITEM_DEKU_STICK;
+    gSaveContext.save.saveInfo.inventory.ammo[SLOT_DEKU_STICK] = 10;
+    gSaveContext.save.saveInfo.inventory.items[SLOT_DEKU_NUT] = ITEM_DEKU_NUT;
+    gSaveContext.save.saveInfo.inventory.ammo[SLOT_DEKU_NUT] = 20;
+
     gSaveContext.save.saveInfo.horseData.sceneId = SCENE_F01;
     gSaveContext.save.saveInfo.horseData.pos.x = -1420;
     gSaveContext.save.saveInfo.horseData.pos.y = 257;

--- a/src/item_give.c
+++ b/src/item_give.c
@@ -1937,9 +1937,11 @@ u8 randoItemGive(u32 gi) {
             return ITEM_NONE;
         } else if (CUR_UPG_VALUE(UPG_WALLET) == 1) {
             Inventory_ChangeUpgrade(UPG_WALLET, 2);
+            Rupees_ChangeBy(500);
             return ITEM_NONE;
         }
         Inventory_ChangeUpgrade(UPG_WALLET, 1);
+        Rupees_ChangeBy(200);
         return ITEM_NONE;
 
     } else if (item == ITEM_DEKU_STICK_UPGRADE_20) {

--- a/src/shooting_gallery_hooks.c
+++ b/src/shooting_gallery_hooks.c
@@ -127,6 +127,9 @@ RECOMP_PATCH void EnSyatekiMan_Town_SetupGiveReward(EnSyatekiMan* this, PlayStat
                 Actor_OfferGetItem(&this->actor, play, GI_RUPEE_HUGE, 500.0f, 100.0f);
             } else {
                 Actor_OfferGetItem(&this->actor, play, GI_HEART_PIECE, 500.0f, 100.0f);
+                if (!rando_location_is_checked(GI_QUIVER_40)) {
+                    rando_send_location(GI_QUIVER_40);
+                }
             }
         } else {
             if (rando_location_is_checked(GI_QUIVER_40)) {


### PR DESCRIPTION
I mainly added these for myself, haven't done extensive testing however these all seem to work.
- Shooting gallery perfect score now gives both rewards: https://github.com/LittleCube-hax/MMRecompRando/issues/6
- Incoming wallets are fully filled (including child wallet)
- Saves start with full consumables (10 sticks, 20 nuts)
- When active, Chateau Romani is added back into the inventory after a cycle reset (currently overwrites bottle slot 1)