### PR TITLE
Add Custom Color Modifications

### DIFF
--- a/src/button_color.c
+++ b/src/button_color.c
@@ -300,3 +300,171 @@ RECOMP_PATCH void Interface_DrawAButton(PlayState* play) {
 
     CLOSE_DISPS(play->state.gfxCtx);
 }
+
+extern s16 sOcarinaButtonAPrimR;
+extern s16 sOcarinaButtonAPrimB;
+extern s16 sOcarinaButtonAPrimG;
+extern s16 sOcarinaButtonAEnvR;
+extern s16 sOcarinaButtonAEnvB;
+extern s16 sOcarinaButtonAEnvG;
+extern s16 sOcarinaButtonCPrimR;
+extern s16 sOcarinaButtonCPrimB;
+extern s16 sOcarinaButtonCPrimG;
+extern s16 sOcarinaButtonCEnvR;
+extern s16 sOcarinaButtonCEnvB;
+extern s16 sOcarinaButtonCEnvG;
+
+void Message_ResetOcarinaButtonAlphas(void);
+
+RECOMP_PATCH void Message_ResetOcarinaButtonState(PlayState* play) {
+    MessageContext* msgCtx = &play->msgCtx;
+
+    msgCtx->ocarinaButtonsPosY[OCARINA_BTN_A] = 189;
+    msgCtx->ocarinaButtonsPosY[OCARINA_BTN_C_DOWN] = 184;
+    msgCtx->ocarinaButtonsPosY[OCARINA_BTN_C_RIGHT] = 179;
+    msgCtx->ocarinaButtonsPosY[OCARINA_BTN_C_LEFT] = 174;
+    msgCtx->ocarinaButtonsPosY[OCARINA_BTN_C_UP] = 169;
+
+    Message_ResetOcarinaButtonAlphas();
+
+    // sOcarinaButtonAPrimR = 80;
+    // sOcarinaButtonAPrimG = 150;
+    // sOcarinaButtonAPrimB = 255;
+    sOcarinaButtonAPrimR = buttonAColor.r;
+    sOcarinaButtonAPrimG = buttonAColor.g;
+    sOcarinaButtonAPrimB = buttonAColor.b;
+    sOcarinaButtonAEnvR = 10;
+    sOcarinaButtonAEnvG = 10;
+    sOcarinaButtonAEnvB = 10;
+    // sOcarinaButtonCPrimR = 255;
+    // sOcarinaButtonCPrimG = 255;
+    // sOcarinaButtonCPrimB = 50;
+    sOcarinaButtonCPrimR = buttonCColor.r;
+    sOcarinaButtonCPrimG = buttonCColor.g;
+    sOcarinaButtonCPrimB = buttonCColor.b;
+    sOcarinaButtonCEnvR = 10;
+    sOcarinaButtonCEnvG = 10;
+    sOcarinaButtonCEnvB = 10;
+}
+
+extern s32 sCharTexSize;
+extern s32 sCharTexScale;
+
+RECOMP_PATCH void Message_DrawTextboxIcon(PlayState* play, Gfx** gfxP, s16 x, s16 y) {
+    // static Color_RGB16 sIconPrimColors[] = {
+    //     { 0, 80, 200 },
+    //     { 50, 130, 255 },
+    // };
+    // static Color_RGB16 sIconEnvColors[] = {
+    //     { 0, 0, 0 },
+    //     { 0, 130, 255 },
+    // };
+    // static s16 sIconPrimR = 0;
+    // static s16 sIconPrimG = 80;
+    // static s16 sIconPrimB = 200;
+    
+    // TODO: add flashing back?
+    Color_RGB16 sIconPrimColors[] = {
+        {buttonAColor.r, buttonAColor.g, buttonAColor.b},
+        {buttonAColor.r, buttonAColor.g, buttonAColor.b},
+    };
+    static Color_RGB16 sIconEnvColors[] = {
+        { 0, 0, 0 },
+        { 255, 255, 255 },
+    };
+    s16 sIconPrimR = buttonAColor.r;
+    s16 sIconPrimG = buttonAColor.g;
+    s16 sIconPrimB = buttonAColor.b;
+    
+    static s16 sIconFlashTimer = 12;
+    static s16 sIconFlashColorIndex = 0;
+    static s16 sIconEnvR = 0;
+    static s16 sIconEnvG = 0;
+    static s16 sIconEnvB = 0;
+    Gfx* gfx;
+    MessageContext* msgCtx = &play->msgCtx;
+    Font* font = &msgCtx->font;
+    s16 primR;
+    s16 primG;
+    s16 primB;
+    s16 envR;
+    s16 envG;
+    s16 envB;
+    u8* iconTexture = msgCtx->font.iconBuf;
+
+    gfx = *gfxP;
+
+    if (!msgCtx->textIsCredits) {
+        primR = ABS_ALT(sIconPrimR - sIconPrimColors[sIconFlashColorIndex].r) / sIconFlashTimer;
+        primG = ABS_ALT(sIconPrimG - sIconPrimColors[sIconFlashColorIndex].g) / sIconFlashTimer;
+        primB = ABS_ALT(sIconPrimB - sIconPrimColors[sIconFlashColorIndex].b) / sIconFlashTimer;
+
+        if (sIconPrimR >= sIconPrimColors[sIconFlashColorIndex].r) {
+            sIconPrimR -= primR;
+        } else {
+            sIconPrimR += primR;
+        }
+
+        if (sIconPrimG >= sIconPrimColors[sIconFlashColorIndex].g) {
+            sIconPrimG -= primG;
+        } else {
+            sIconPrimG += primG;
+        }
+
+        if (sIconPrimB >= sIconPrimColors[sIconFlashColorIndex].b) {
+            sIconPrimB -= primB;
+        } else {
+            sIconPrimB += primB;
+        }
+
+        envR = ABS_ALT(sIconEnvR - sIconEnvColors[sIconFlashColorIndex].r) / sIconFlashTimer;
+        envG = ABS_ALT(sIconEnvG - sIconEnvColors[sIconFlashColorIndex].g) / sIconFlashTimer;
+        envB = ABS_ALT(sIconEnvB - sIconEnvColors[sIconFlashColorIndex].b) / sIconFlashTimer;
+
+        if (sIconEnvR >= sIconEnvColors[sIconFlashColorIndex].r) {
+            sIconEnvR -= envR;
+        } else {
+            sIconEnvR += envR;
+        }
+
+        if (sIconEnvG >= sIconEnvColors[sIconFlashColorIndex].g) {
+            sIconEnvG -= envG;
+        } else {
+            sIconEnvG += envG;
+        }
+
+        if (sIconEnvB >= sIconEnvColors[sIconFlashColorIndex].b) {
+            sIconEnvB -= envB;
+        } else {
+            sIconEnvB += envB;
+        }
+
+        sIconFlashTimer--;
+        if (sIconFlashTimer == 0) {
+            sIconPrimR = sIconPrimColors[sIconFlashColorIndex].r;
+            sIconPrimG = sIconPrimColors[sIconFlashColorIndex].g;
+            sIconPrimB = sIconPrimColors[sIconFlashColorIndex].b;
+            sIconEnvR = sIconEnvColors[sIconFlashColorIndex].r;
+            sIconEnvG = sIconEnvColors[sIconFlashColorIndex].g;
+            sIconEnvB = sIconEnvColors[sIconFlashColorIndex].b;
+            sIconFlashTimer = 12;
+            sIconFlashColorIndex ^= 1;
+        }
+
+        gDPPipeSync(gfx++);
+        gDPSetCombineLERP(gfx++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0, PRIMITIVE,
+                          ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+        gDPSetPrimColor(gfx++, 0, 0, sIconPrimR, sIconPrimG, sIconPrimB, 255);
+        gDPSetEnvColor(gfx++, sIconEnvR, sIconEnvG, sIconEnvB, 255);
+
+        if (!play->pauseCtx.bombersNotebookOpen) {
+            gDPLoadTextureBlock_4b(gfx++, iconTexture, G_IM_FMT_I, 16, 16, 0, G_TX_NOMIRROR | G_TX_CLAMP,
+                                   G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+            gSPTextureRectangle(gfx++, x << 2, y << 2, (x + sCharTexSize) << 2, (y + sCharTexSize) << 2,
+                                G_TX_RENDERTILE, 0, 0, sCharTexScale, sCharTexScale);
+        }
+
+        msgCtx->stateTimer++;
+        *gfxP = gfx;
+    }
+}

--- a/src/button_color.c
+++ b/src/button_color.c
@@ -1,0 +1,302 @@
+#include "modding.h"
+#include "global.h"
+
+// TODO: apply colors to song playing + message boxes
+// set to default values for now
+Color_RGB8 buttonBColor = {100, 255, 120};
+Color_RGB8 buttonCColor = {255, 240, 0};
+Color_RGB8 buttonAColor = {100, 200, 255};
+Color_RGB8 buttonStartColor = {255, 130, 60};
+
+extern u64 gTatlCUpENGTex[];
+extern u64 gTatlCUpGERTex[];
+extern u64 gTatlCUpFRATex[];
+extern u64 gTatlCUpESPTex[];
+extern u64 gButtonBackgroundTex[];
+
+s16 D_801BF9D4[] = {
+    0xA7,  // EQUIP_SLOT_B
+    0xE3,  // EQUIP_SLOT_C_LEFT
+    0xF9,  // EQUIP_SLOT_C_DOWN
+    0x10F, // EQUIP_SLOT_C_RIGHT
+};
+s16 D_801BF9DC[] = {
+    0x11, // EQUIP_SLOT_B
+    0x12, // EQUIP_SLOT_C_LEFT
+    0x22, // EQUIP_SLOT_C_DOWN
+    0x12, // EQUIP_SLOT_C_RIGHT
+};
+s16 D_801BF9E4[] = {
+    0x23F, // EQUIP_SLOT_B
+    0x26C, // EQUIP_SLOT_C_LEFT
+    0x26C, // EQUIP_SLOT_C_DOWN
+    0x26C, // EQUIP_SLOT_C_RIGHT
+};
+
+#define IS_PAUSE_STATE_GAMEOVER \
+    ((pauseCtx->state >= PAUSE_STATE_GAMEOVER_0) && (pauseCtx->state <= PAUSE_STATE_GAMEOVER_10))
+
+typedef enum {
+    /* 0x00 */ PAUSE_STATE_OFF,
+    /* 0x01 */ PAUSE_STATE_OPENING_0,
+    /* 0x02 */ PAUSE_STATE_OPENING_1,
+    /* 0x03 */ PAUSE_STATE_OPENING_2,
+    /* 0x04 */ PAUSE_STATE_OPENING_3,
+    /* 0x05 */ PAUSE_STATE_OPENING_4,
+    /* 0x06 */ PAUSE_STATE_MAIN, // Pause menu ready for player inputs.
+    /* 0x07 */ PAUSE_STATE_SAVEPROMPT,
+    /* 0x08 */ PAUSE_STATE_GAMEOVER_0,
+    /* 0x09 */ PAUSE_STATE_GAMEOVER_1,
+    /* 0x0A */ PAUSE_STATE_GAMEOVER_2,
+    /* 0x0B */ PAUSE_STATE_GAMEOVER_3,
+    /* 0x0C */ PAUSE_STATE_GAMEOVER_4,
+    /* 0x0D */ PAUSE_STATE_GAMEOVER_5,
+    /* 0x0E */ PAUSE_STATE_GAMEOVER_SAVE_PROMPT,
+    /* 0x0F */ PAUSE_STATE_GAMEOVER_7,
+    /* 0x10 */ PAUSE_STATE_GAMEOVER_8,
+    /* 0x11 */ PAUSE_STATE_GAMEOVER_CONTINUE_PROMPT,
+    /* 0x12 */ PAUSE_STATE_GAMEOVER_10,
+    /* 0x13 */ PAUSE_STATE_OWLWARP_0,
+    /* 0x14 */ PAUSE_STATE_OWLWARP_1,
+    /* 0x15 */ PAUSE_STATE_OWLWARP_2,
+    /* 0x16 */ PAUSE_STATE_OWLWARP_3,
+    /* 0x17 */ PAUSE_STATE_OWLWARP_SELECT, // Selecting the destination
+    /* 0x18 */ PAUSE_STATE_OWLWARP_CONFIRM, // Confirming the choice given
+    /* 0x19 */ PAUSE_STATE_OWLWARP_6,
+    /* 0x1A */ PAUSE_STATE_UNPAUSE_SETUP, // Unpause
+    /* 0x1B */ PAUSE_STATE_UNPAUSE_CLOSE
+} PauseState;
+
+typedef enum {
+    /* 0 */ DEBUG_EDITOR_NONE,
+    /* 1 */ DEBUG_EDITOR_INVENTORY_INIT,
+    /* 2 */ DEBUG_EDITOR_INVENTORY,
+    /* 3 */ DEBUG_EDITOR_EVENTS
+} DebugEditor;
+
+#define DO_ACTION_TEX_WIDTH 48
+#define DO_ACTION_TEX_HEIGHT 16
+#define DO_ACTION_TEX_SIZE ((DO_ACTION_TEX_WIDTH * DO_ACTION_TEX_HEIGHT) / 2)
+
+typedef enum {
+    /* 0 */ PICTO_BOX_STATE_OFF,         // Not using the pictograph
+    /* 1 */ PICTO_BOX_STATE_LENS,        // Looking through the lens of the pictograph
+    /* 2 */ PICTO_BOX_STATE_SETUP_PHOTO, // Looking at the photo currently taken
+    /* 3 */ PICTO_BOX_STATE_PHOTO
+} PictoBoxState;
+s16 sPictoState = PICTO_BOX_STATE_OFF;
+
+u16 sCUpInvisible = 0;
+u16 sCUpTimer = 0;
+
+Gfx* Gfx_DrawTexRectIA8_DropShadow(Gfx* gfx, TexturePtr texture, s16 textureWidth, s16 textureHeight, s16 rectLeft,
+                                   s16 rectTop, s16 rectWidth, s16 rectHeight, u16 dsdx, u16 dtdy, s16 r, s16 g, s16 b,
+                                   s16 a);
+Gfx* Gfx_DrawRect_DropShadow(Gfx* gfx, s16 rectLeft, s16 rectTop, s16 rectWidth, s16 rectHeight, u16 dsdx, u16 dtdy,
+                             s16 r, s16 g, s16 b, s16 a);
+
+
+RECOMP_PATCH void Interface_DrawItemButtons(PlayState* play) {
+    static TexturePtr cUpLabelTextures[] = {
+        gTatlCUpENGTex, gTatlCUpENGTex, gTatlCUpGERTex, gTatlCUpFRATex, gTatlCUpESPTex,
+    };
+    static s16 startButtonLeftPos[] = {
+        // Remnant of OoT
+        130, 136, 136, 136, 136,
+    };
+    static s16 D_801BFAF4[] = {
+        0x1D, // EQUIP_SLOT_B
+        0x1B, // EQUIP_SLOT_C_LEFT
+        0x1B, // EQUIP_SLOT_C_DOWN
+        0x1B, // EQUIP_SLOT_C_RIGHT
+    };
+    InterfaceContext* interfaceCtx = &play->interfaceCtx;
+    Player* player = GET_PLAYER(play);
+    PauseContext* pauseCtx = &play->pauseCtx;
+    MessageContext* msgCtx = &play->msgCtx;
+    s16 temp; // Used as both an alpha value and a button index
+    s32 pad;
+
+    OPEN_DISPS(play->state.gfxCtx);
+
+    gDPPipeSync(OVERLAY_DISP++);
+    gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
+
+    // B Button Color & Texture
+    // OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadow(
+    //     OVERLAY_DISP, gButtonBackgroundTex, 0x20, 0x20, D_801BF9D4[EQUIP_SLOT_B], D_801BF9DC[EQUIP_SLOT_B],
+    //     D_801BFAF4[EQUIP_SLOT_B], D_801BFAF4[EQUIP_SLOT_B], D_801BF9E4[EQUIP_SLOT_B] * 2, D_801BF9E4[EQUIP_SLOT_B] * 2,
+    //     100, 255, 120, interfaceCtx->bAlpha);
+    OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadow(
+        OVERLAY_DISP, gButtonBackgroundTex, 0x20, 0x20, D_801BF9D4[EQUIP_SLOT_B], D_801BF9DC[EQUIP_SLOT_B],
+        D_801BFAF4[EQUIP_SLOT_B], D_801BFAF4[EQUIP_SLOT_B], D_801BF9E4[EQUIP_SLOT_B] * 2, D_801BF9E4[EQUIP_SLOT_B] * 2,
+        buttonBColor.r, buttonBColor.g, buttonBColor.b, interfaceCtx->bAlpha);
+    gDPPipeSync(OVERLAY_DISP++);
+
+    // C-Left Button Color & Texture
+    OVERLAY_DISP = Gfx_DrawRect_DropShadow(OVERLAY_DISP, D_801BF9D4[EQUIP_SLOT_C_LEFT], D_801BF9DC[EQUIP_SLOT_C_LEFT],
+                                           D_801BFAF4[EQUIP_SLOT_C_LEFT], D_801BFAF4[EQUIP_SLOT_C_LEFT],
+                                           D_801BF9E4[EQUIP_SLOT_C_LEFT] * 2, D_801BF9E4[EQUIP_SLOT_C_LEFT] * 2, 
+										   buttonCColor.r, buttonCColor.g, buttonCColor.b, interfaceCtx->cLeftAlpha);
+    // C-Down Button Color & Texture
+    OVERLAY_DISP = Gfx_DrawRect_DropShadow(OVERLAY_DISP, D_801BF9D4[EQUIP_SLOT_C_DOWN], D_801BF9DC[EQUIP_SLOT_C_DOWN],
+                                           D_801BFAF4[EQUIP_SLOT_C_DOWN], D_801BFAF4[EQUIP_SLOT_C_DOWN],
+                                           D_801BF9E4[EQUIP_SLOT_C_DOWN] * 2, D_801BF9E4[EQUIP_SLOT_C_DOWN] * 2,
+										   buttonCColor.r, buttonCColor.g, buttonCColor.b, interfaceCtx->cDownAlpha);
+    // C-Right Button Color & Texture
+    OVERLAY_DISP = Gfx_DrawRect_DropShadow(OVERLAY_DISP, D_801BF9D4[EQUIP_SLOT_C_RIGHT], D_801BF9DC[EQUIP_SLOT_C_RIGHT],
+                                           D_801BFAF4[EQUIP_SLOT_C_RIGHT], D_801BFAF4[EQUIP_SLOT_C_RIGHT],
+                                           D_801BF9E4[EQUIP_SLOT_C_RIGHT] * 2, D_801BF9E4[EQUIP_SLOT_C_RIGHT] * 2,
+										   buttonCColor.r, buttonCColor.g, buttonCColor.b, interfaceCtx->cRightAlpha);
+
+    if (!IS_PAUSE_STATE_GAMEOVER) {
+        if ((play->pauseCtx.state != PAUSE_STATE_OFF) || (play->pauseCtx.debugEditor != DEBUG_EDITOR_NONE)) {
+            // OVERLAY_DISP = Gfx_DrawRect_DropShadow(OVERLAY_DISP, 0x88, 0x11, 0x16, 0x16, 0x5B6, 0x5B6, 0xFF, 0x82, 0x3C,
+            //                                        interfaceCtx->startAlpha);
+            OVERLAY_DISP = Gfx_DrawRect_DropShadow(OVERLAY_DISP, 0x88, 0x11, 0x16, 0x16, 0x5B6, 0x5B6,
+													buttonStartColor.r, buttonStartColor.g, buttonStartColor.b, interfaceCtx->startAlpha);
+            // Start Button Texture, Color & Label
+            gDPPipeSync(OVERLAY_DISP++);
+            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->startAlpha);
+            gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 0);
+            gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
+                              PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+            gDPLoadTextureBlock_4b(OVERLAY_DISP++, interfaceCtx->doActionSegment + DO_ACTION_TEX_SIZE * 2, G_IM_FMT_IA,
+                                   DO_ACTION_TEX_WIDTH, DO_ACTION_TEX_HEIGHT, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                                   G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+            gSPTextureRectangle(OVERLAY_DISP++, 0x01F8, 0x0054, 0x02D4, 0x009C, G_TX_RENDERTILE, 0, 0, 0x04A6, 0x04A6);
+        }
+    }
+
+    if (interfaceCtx->tatlCalling && (play->pauseCtx.state == PAUSE_STATE_OFF) &&
+        (play->pauseCtx.debugEditor == DEBUG_EDITOR_NONE) && (play->csCtx.state == CS_STATE_IDLE) &&
+        (sPictoState == PICTO_BOX_STATE_OFF)) {
+        if (sCUpInvisible == 0) {
+            // C-Up Button Texture, Color & Label (Tatl Text)
+            gDPPipeSync(OVERLAY_DISP++);
+
+            if ((gSaveContext.hudVisibility == HUD_VISIBILITY_NONE) ||
+                (gSaveContext.hudVisibility == HUD_VISIBILITY_NONE_ALT) ||
+                (gSaveContext.hudVisibility == HUD_VISIBILITY_A_HEARTS_MAGIC_WITH_OVERWRITE) ||
+                (msgCtx->msgMode != MSGMODE_NONE)) {
+                temp = 0;
+            } else if (player->stateFlags1 & PLAYER_STATE1_200000) {
+                temp = 70;
+            } else {
+                temp = interfaceCtx->aAlpha;
+            }
+
+            OVERLAY_DISP =
+                // Gfx_DrawRect_DropShadow(OVERLAY_DISP, 0xFE, 0x10, 0x10, 0x10, 0x800, 0x800, 0xFF, 0xF0, 0, temp);
+                Gfx_DrawRect_DropShadow(OVERLAY_DISP, 0xFE, 0x10, 0x10, 0x10, 0x800, 0x800, buttonCColor.r, buttonCColor.g, buttonCColor.b, temp);
+
+            gDPPipeSync(OVERLAY_DISP++);
+            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, temp);
+            gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 0);
+            gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
+                              PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+            gDPLoadTextureBlock_4b(OVERLAY_DISP++, cUpLabelTextures[gSaveContext.options.language], G_IM_FMT_IA, 32, 12,
+                                   0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
+                                   G_TX_NOLOD, G_TX_NOLOD);
+            gSPTextureRectangle(OVERLAY_DISP++, 0x03DC, 0x0048, 0x045C, 0x0078, G_TX_RENDERTILE, 0, 0, 1 << 10,
+                                1 << 10);
+        }
+
+        sCUpTimer--;
+        if (sCUpTimer == 0) {
+            sCUpInvisible ^= 1;
+            sCUpTimer = 10;
+        }
+    }
+
+    gDPPipeSync(OVERLAY_DISP++);
+
+    // Empty C Button Arrows
+    for (temp = EQUIP_SLOT_C_LEFT; temp <= EQUIP_SLOT_C_RIGHT; temp++) {
+        if (GET_CUR_FORM_BTN_ITEM(temp) > 0xF0) {
+            if (temp == EQUIP_SLOT_C_LEFT) {
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, buttonCColor.r, buttonCColor.g, buttonCColor.b, interfaceCtx->cLeftAlpha);
+            } else if (temp == EQUIP_SLOT_C_DOWN) {
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, buttonCColor.r, buttonCColor.g, buttonCColor.b, interfaceCtx->cDownAlpha);
+            } else { // EQUIP_SLOT_C_RIGHT
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, buttonCColor.r, buttonCColor.g, buttonCColor.b, interfaceCtx->cRightAlpha);
+            }
+            OVERLAY_DISP = Gfx_DrawTexRectIA8(OVERLAY_DISP, ((u8*)gButtonBackgroundTex + ((32 * 32) * (temp + 1))),
+                                              0x20, 0x20, D_801BF9D4[temp], D_801BF9DC[temp], D_801BFAF4[temp],
+                                              D_801BFAF4[temp], D_801BF9E4[temp] * 2, D_801BF9E4[temp] * 2);
+        }
+    }
+
+    CLOSE_DISPS(play->state.gfxCtx);
+}
+
+f32 D_801BF9CC[] = { -380.0f, -350.0f };
+
+void Interface_SetPerspectiveView(PlayState* play, s32 topY, s32 bottomY, s32 leftX, s32 rightX);
+void Interface_SetPerfectLetters(PlayState* play, s16 perfectLettersType);
+
+RECOMP_PATCH void Interface_DrawAButton(PlayState* play) {
+    InterfaceContext* interfaceCtx = &play->interfaceCtx;
+    s16 aAlpha;
+
+    OPEN_DISPS(play->state.gfxCtx);
+
+    aAlpha = interfaceCtx->aAlpha;
+
+    if (aAlpha > 100) {
+        aAlpha = 100;
+    }
+
+    Gfx_SetupDL42_Overlay(play->state.gfxCtx);
+
+    Interface_SetPerspectiveView(play, 25 + R_A_BTN_Y_OFFSET, 70 + R_A_BTN_Y_OFFSET, 192, 237);
+
+    gSPClearGeometryMode(OVERLAY_DISP++, G_CULL_BOTH);
+    gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
+    gDPSetAlphaCompare(OVERLAY_DISP++, G_AC_THRESHOLD);
+
+    Matrix_Translate(0.0f, 0.0f, -38.0f, MTXMODE_NEW);
+    Matrix_Scale(1.0f, 1.0f, 1.0f, MTXMODE_APPLY);
+    Matrix_RotateXFApply(interfaceCtx->aButtonRoll / 10000.0f);
+
+    // Draw A button Shadow
+    gSPMatrix(OVERLAY_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gDPPipeSync(OVERLAY_DISP++);
+    gSPVertex(OVERLAY_DISP++, &interfaceCtx->actionVtx[4], 4, 0);
+    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 0, 0, aAlpha);
+
+    OVERLAY_DISP = Gfx_DrawTexQuadIA8(OVERLAY_DISP, gButtonBackgroundTex, 32, 32, 0);
+
+    // Draw A Button Colored
+    gDPPipeSync(OVERLAY_DISP++);
+    Interface_SetPerspectiveView(play, 23 + R_A_BTN_Y_OFFSET, 68 + R_A_BTN_Y_OFFSET, 190, 235);
+    gSPVertex(OVERLAY_DISP++, &interfaceCtx->actionVtx[0], 4, 0);
+    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, buttonAColor.r, buttonAColor.g, buttonAColor.b, interfaceCtx->aAlpha);
+    gSP1Quadrangle(OVERLAY_DISP++, 0, 2, 3, 1, 0);
+
+    // Draw A Button Do-Action
+    gDPPipeSync(OVERLAY_DISP++);
+    Interface_SetPerspectiveView(play, 23 + R_A_BTN_Y_OFFSET, 68 + R_A_BTN_Y_OFFSET, 190, 235);
+    gSPSetGeometryMode(OVERLAY_DISP++, G_CULL_BACK);
+    gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0, PRIMITIVE,
+                      ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->aAlpha);
+    gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 0);
+
+    Matrix_Translate(0.0f, 0.0f, D_801BF9CC[gSaveContext.options.language] / 10.0f, MTXMODE_NEW);
+    Matrix_Scale(1.0f, 1.0f, 1.0f, MTXMODE_APPLY);
+    Matrix_RotateXFApply(interfaceCtx->aButtonRoll / 10000.0f);
+    gSPMatrix(OVERLAY_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPVertex(OVERLAY_DISP++, &interfaceCtx->actionVtx[8], 4, 0);
+
+    // Draw Action Label
+    if (((interfaceCtx->aButtonState <= A_BTN_STATE_1) || (interfaceCtx->aButtonState == A_BTN_STATE_3))) {
+        OVERLAY_DISP = Gfx_DrawTexQuad4b(OVERLAY_DISP, interfaceCtx->doActionSegment, 3, DO_ACTION_TEX_WIDTH,
+                                         DO_ACTION_TEX_HEIGHT, 0);
+    } else {
+        OVERLAY_DISP = Gfx_DrawTexQuad4b(OVERLAY_DISP, interfaceCtx->doActionSegment + DO_ACTION_TEX_SIZE, 3,
+                                         DO_ACTION_TEX_WIDTH, DO_ACTION_TEX_HEIGHT, 0);
+    }
+
+    CLOSE_DISPS(play->state.gfxCtx);
+}

--- a/src/file_color.c
+++ b/src/file_color.c
@@ -1,0 +1,218 @@
+#include "modding.h"
+#include "global.h"
+
+// TODO: also recolor all shared elements (i.e. hearts)
+// set to default values for now
+Color_RGB16 windowColor = {100, 150, 255};
+
+// s16 sWindowContentColors[] = { 100, 150, 255 };
+extern s16 sWindowContentColors[];
+
+#include "overlays/gamestates/ovl_file_choose/z_file_select.h"
+
+extern TexturePtr sTitleLabels[];
+extern TexturePtr sFileInfoBoxTextures[];
+extern s16 sFileInfoBoxPartWidths[];
+extern TexturePtr sFileButtonTextures[];
+extern u64 gFileSelFileNameBoxTex[];
+extern u64 gFileSelConnectorTex[];
+extern u64 gFileSelBlankButtonTex[];
+extern TexturePtr sActionButtonTextures[];
+extern u64 gFileSelOptionsButtonENGTex[];
+extern u64 gFileSelBigButtonHighlightTex[];
+extern TexturePtr sWarningLabels[];
+
+void FileSelect_DrawFileInfo(GameState* thisx, s16 fileIndex);
+
+/**
+ * Draw most window contents including buttons, labels, and icons.
+ * Does not include anything from the keyboard and settings windows.
+ */
+RECOMP_PATCH void FileSelect_DrawWindowContents(GameState* thisx) {
+    FileSelectState* this = (FileSelectState*)thisx;
+    s16 fileIndex;
+    s16 temp;
+    s16 i;
+    s16 quadVtxIndex;
+
+	// this part could be done better, but hey it works
+	sWindowContentColors[0] = windowColor.r;
+	sWindowContentColors[1] = windowColor.g;
+	sWindowContentColors[2] = windowColor.b;
+	this->windowColor[0] = sWindowContentColors[0];
+	this->windowColor[1] = sWindowContentColors[1];
+	this->windowColor[2] = sWindowContentColors[2];
+
+	Skybox_SetColors(&this->skyboxCtx, windowColor.r, windowColor.g, windowColor.b, 0, 0, 0);
+
+    if (1) {}
+
+    OPEN_DISPS(this->state.gfxCtx);
+
+    // draw title label
+    gDPPipeSync(POLY_OPA_DISP++);
+    gDPSetCombineLERP(POLY_OPA_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0, PRIMITIVE,
+                      ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+    gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, this->titleAlpha[FS_TITLE_CUR]);
+    gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
+
+    gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[0], 4, 0);
+    gDPLoadTextureBlock(POLY_OPA_DISP++, sTitleLabels[this->titleLabel], G_IM_FMT_IA, G_IM_SIZ_8b, 128, 16, 0,
+                        G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                        G_TX_NOLOD);
+    gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
+
+    // draw next title label
+    gDPPipeSync(POLY_OPA_DISP++);
+    gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, this->titleAlpha[FS_TITLE_NEXT]);
+    gDPLoadTextureBlock(POLY_OPA_DISP++, sTitleLabels[this->nextTitleLabel], G_IM_FMT_IA, G_IM_SIZ_8b, 128, 16, 0,
+                        G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                        G_TX_NOLOD);
+    gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
+
+    temp = 4;
+
+    gDPPipeSync(POLY_OPA_DISP++);
+
+    // draw file info box (large box when a file is selected)
+    for (fileIndex = 0; fileIndex < 3; fileIndex++, temp += 28) {
+        if (fileIndex < 2) {
+            gDPPipeSync(POLY_OPA_DISP++);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
+                            this->fileInfoAlpha[fileIndex]);
+            gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[temp], 28, 0);
+
+            for (quadVtxIndex = 0, i = 0; i < 7; i++, quadVtxIndex += 4) {
+                if ((i < 5) || (this->isOwlSave[fileIndex + 2] && (i >= 5))) {
+                    gDPLoadTextureBlock(POLY_OPA_DISP++, sFileInfoBoxTextures[i], G_IM_FMT_IA, G_IM_SIZ_16b,
+                                        sFileInfoBoxPartWidths[i], 56, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                                        G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+                    gSP1Quadrangle(POLY_OPA_DISP++, quadVtxIndex, quadVtxIndex + 2, quadVtxIndex + 3, quadVtxIndex + 1,
+                                   0);
+                }
+            }
+        }
+    }
+
+    gDPPipeSync(POLY_OPA_DISP++);
+
+    for (i = 0; i < 3; i++, temp += 16) {
+        if (i < 2) {
+            // draw file button
+            gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[temp], 16, 0);
+
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, sWindowContentColors[0], sWindowContentColors[1],
+                            sWindowContentColors[2], this->fileButtonAlpha[i]);
+            gDPLoadTextureBlock(POLY_OPA_DISP++, sFileButtonTextures[i], G_IM_FMT_IA, G_IM_SIZ_16b, 64, 16, 0,
+                                G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
+                                G_TX_NOLOD, G_TX_NOLOD);
+            gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
+
+            // draw file name box
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, sWindowContentColors[0], sWindowContentColors[1],
+                            sWindowContentColors[2], this->nameBoxAlpha[i]);
+            gDPLoadTextureBlock(POLY_OPA_DISP++, gFileSelFileNameBoxTex, G_IM_FMT_IA, G_IM_SIZ_16b, 108, 16, 0,
+                                G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
+                                G_TX_NOLOD, G_TX_NOLOD);
+            gSP1Quadrangle(POLY_OPA_DISP++, 4, 6, 7, 5, 0);
+
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, sWindowContentColors[0], sWindowContentColors[1],
+                            sWindowContentColors[2], this->connectorAlpha[i]);
+            gDPLoadTextureBlock(POLY_OPA_DISP++, gFileSelConnectorTex, G_IM_FMT_IA, G_IM_SIZ_8b, 24, 16, 0,
+                                G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
+                                G_TX_NOLOD, G_TX_NOLOD);
+            gSP1Quadrangle(POLY_OPA_DISP++, 8, 10, 11, 9, 0);
+
+            if (this->isOwlSave[i + 2]) {
+                gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, sWindowContentColors[0], sWindowContentColors[1],
+                                sWindowContentColors[2], this->nameBoxAlpha[i]);
+                gDPLoadTextureBlock(POLY_OPA_DISP++, gFileSelBlankButtonTex, G_IM_FMT_IA, G_IM_SIZ_16b, 52, 16, 0,
+                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
+                                    G_TX_NOLOD, G_TX_NOLOD);
+                gSP1Quadrangle(POLY_OPA_DISP++, 12, 14, 15, 13, 0);
+            }
+        }
+    }
+
+    // draw file info
+    for (fileIndex = 0; fileIndex < 2; fileIndex++) {
+        FileSelect_DrawFileInfo(&this->state, fileIndex);
+    }
+
+    gDPPipeSync(POLY_OPA_DISP++);
+    gDPSetCombineLERP(POLY_OPA_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0, PRIMITIVE,
+                      ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+    gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
+    gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[0x3AC], 20, 0);
+
+    // draw primary action buttons (copy/erase)
+    for (quadVtxIndex = 0, i = 0; i < 2; i++, quadVtxIndex += 4) {
+        gDPPipeSync(POLY_OPA_DISP++);
+        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
+                        this->actionButtonAlpha[i]);
+        gDPLoadTextureBlock(POLY_OPA_DISP++, sActionButtonTextures[i], G_IM_FMT_IA, G_IM_SIZ_16b, 64, 16, 0,
+                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                            G_TX_NOLOD);
+        gSP1Quadrangle(POLY_OPA_DISP++, quadVtxIndex, quadVtxIndex + 2, quadVtxIndex + 3, quadVtxIndex + 1, 0);
+    }
+
+    gDPPipeSync(POLY_OPA_DISP++);
+
+    // draw confirm buttons (yes/quit)
+    for (quadVtxIndex = 0, i = FS_BTN_CONFIRM_YES; i <= FS_BTN_CONFIRM_QUIT; i++, quadVtxIndex += 4) {
+        temp = this->confirmButtonTexIndices[i];
+        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
+                        this->confirmButtonAlpha[i]);
+        gDPLoadTextureBlock(POLY_OPA_DISP++, sActionButtonTextures[temp], G_IM_FMT_IA, G_IM_SIZ_16b, 64, 16, 0,
+                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                            G_TX_NOLOD);
+        gSP1Quadrangle(POLY_OPA_DISP++, quadVtxIndex, quadVtxIndex + 2, quadVtxIndex + 3, quadVtxIndex + 1, 0);
+    }
+
+    // draw options button
+    gDPPipeSync(POLY_OPA_DISP++);
+    gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
+                    this->optionButtonAlpha);
+    gDPLoadTextureBlock(POLY_OPA_DISP++, gFileSelOptionsButtonENGTex, G_IM_FMT_IA, G_IM_SIZ_16b, 64, 16, 0,
+                        G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                        G_TX_NOLOD);
+    gSP1Quadrangle(POLY_OPA_DISP++, 8, 10, 11, 9, 0);
+
+    // draw highlight over currently selected button
+    if (((this->menuMode == FS_MENU_MODE_CONFIG) &&
+         ((this->configMode == CM_MAIN_MENU) || (this->configMode == CM_SELECT_COPY_SOURCE) ||
+          (this->configMode == CM_SELECT_COPY_DEST) || (this->configMode == CM_COPY_CONFIRM) ||
+          (this->configMode == CM_ERASE_SELECT) || (this->configMode == CM_ERASE_CONFIRM))) ||
+        ((this->menuMode == FS_MENU_MODE_SELECT) && (this->selectMode == SM_CONFIRM_FILE))) {
+        gDPPipeSync(POLY_OPA_DISP++);
+
+        gDPSetCombineLERP(POLY_OPA_DISP++, 1, 0, PRIMITIVE, 0, TEXEL0, 0, PRIMITIVE, 0, 1, 0, PRIMITIVE, 0, TEXEL0, 0,
+                          PRIMITIVE, 0);
+        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->highlightColor[0], this->highlightColor[1],
+                        this->highlightColor[2], this->highlightColor[3]);
+        gDPLoadTextureBlock(POLY_OPA_DISP++, gFileSelBigButtonHighlightTex, G_IM_FMT_I, G_IM_SIZ_8b, 72, 24, 0,
+                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                            G_TX_NOLOD);
+        gSP1Quadrangle(POLY_OPA_DISP++, 12, 14, 15, 13, 0);
+    }
+
+    // draw warning labels
+    if (this->warningLabel > FS_WARNING_NONE) {
+        gDPPipeSync(POLY_OPA_DISP++);
+
+        gDPSetCombineLERP(POLY_OPA_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
+                          PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, this->emptyFileTextAlpha);
+        gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
+        gDPLoadTextureBlock(POLY_OPA_DISP++, sWarningLabels[this->warningLabel], G_IM_FMT_IA, G_IM_SIZ_8b, 128, 16, 0,
+                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                            G_TX_NOLOD);
+        gSP1Quadrangle(POLY_OPA_DISP++, 16, 18, 19, 17, 0);
+    }
+
+    gDPPipeSync(POLY_OPA_DISP++);
+
+    gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIDECALA, G_CC_MODULATEIDECALA);
+
+    CLOSE_DISPS(this->state.gfxCtx);
+}

--- a/src/heart_color.c
+++ b/src/heart_color.c
@@ -1,0 +1,123 @@
+#include "modding.h"
+#include "global.h"
+
+// set to default values for now
+Color_RGB8 heartColor = {255, 70, 50};
+Color_RGB8 heartColorBG = {50, 40, 60};
+
+// unsure what some of the below do
+s16 sHeartsPrimColors[3][3] = { { 255, 70, 50 }, { 255, 190, 0 }, { 100, 100, 255 } };
+s16 sHeartsEnvColors[3][3] = { { 50, 40, 60 }, { 255, 0, 0 }, { 0, 0, 255 } };
+s16 sHeartsPrimFactors[3][3] = { { 0, 0, 0 }, { 0, 120, -50 }, { -155, 30, 205 } };
+s16 sHeartsEnvFactors[3][3] = { { 0, 0, 0 }, { 205, -40, -60 }, { -50, -40, 195 } };
+s16 sHeartsDDPrimColors[3][3] = { { 255, 255, 255 }, { 255, 190, 0 }, { 100, 100, 255 } };
+s16 sHeartsDDEnvColors[3][3] = { { 200, 0, 0 }, { 255, 0, 0 }, { 0, 0, 255 } };
+s16 sHeartsDDPrimFactors[3][3] = { { 0, 0, 0 }, { 0, -65, -255 }, { -155, -155, 0 } };
+s16 sHeartsDDEnvFactors[3][3] = { { 0, 0, 0 }, { 55, 0, 0 }, { -200, 0, 255 } };
+
+s16 sBeatingHeartsDDPrim[3];
+s16 sBeatingHeartsDDEnv[3];
+s16 sHeartsDDPrim[2][3];
+s16 sHeartsDDEnv[2][3];
+
+RECOMP_PATCH void LifeMeter_UpdateColors(PlayState* play) {
+    InterfaceContext* interfaceCtx = &play->interfaceCtx;
+    f32 factorBeating = interfaceCtx->lifeColorChange * 0.1f;
+    f32 ddFactor;
+    s32 type = 0;
+    s32 ddType;
+    s16 rFactor;
+    s16 gFactor;
+    s16 bFactor;
+
+    if (interfaceCtx) {}
+
+    if (interfaceCtx->lifeColorChangeDirection != 0) {
+        interfaceCtx->lifeColorChange--;
+        if (interfaceCtx->lifeColorChange <= 0) {
+            interfaceCtx->lifeColorChange = 0;
+            interfaceCtx->lifeColorChangeDirection = 0;
+        }
+    } else {
+        interfaceCtx->lifeColorChange++;
+        if (interfaceCtx->lifeColorChange >= 10) {
+            interfaceCtx->lifeColorChange = 10;
+            interfaceCtx->lifeColorChangeDirection = 1;
+        }
+    }
+
+    ddFactor = factorBeating;
+
+    // interfaceCtx->heartsPrimR[0] = 255;
+    // interfaceCtx->heartsPrimG[0] = 70;
+    // interfaceCtx->heartsPrimB[0] = 50;
+    interfaceCtx->heartsPrimR[0] = heartColor.r;
+    interfaceCtx->heartsPrimG[0] = heartColor.g;
+    interfaceCtx->heartsPrimB[0] = heartColor.b;
+
+    // interfaceCtx->heartsEnvR[0] = 50;
+    // interfaceCtx->heartsEnvG[0] = 40;
+    // interfaceCtx->heartsEnvB[0] = 60;
+    interfaceCtx->heartsEnvR[0] = heartColorBG.r;
+    interfaceCtx->heartsEnvG[0] = heartColorBG.g;
+    interfaceCtx->heartsEnvB[0] = heartColorBG.b;
+
+    interfaceCtx->heartsPrimR[1] = sHeartsPrimColors[type][0];
+    interfaceCtx->heartsPrimG[1] = sHeartsPrimColors[type][1];
+    interfaceCtx->heartsPrimB[1] = sHeartsPrimColors[type][2];
+
+    interfaceCtx->heartsEnvR[1] = sHeartsEnvColors[type][0];
+    interfaceCtx->heartsEnvG[1] = sHeartsEnvColors[type][1];
+    interfaceCtx->heartsEnvB[1] = sHeartsEnvColors[type][2];
+
+    rFactor = sHeartsPrimFactors[0][0] * factorBeating;
+    gFactor = sHeartsPrimFactors[0][1] * factorBeating;
+    bFactor = sHeartsPrimFactors[0][2] * factorBeating;
+
+    interfaceCtx->beatingHeartPrim[0] = (u8)(rFactor + heartColor.r) & 0xFF;
+    interfaceCtx->beatingHeartPrim[1] = (u8)(gFactor + heartColor.g) & 0xFF;
+    interfaceCtx->beatingHeartPrim[2] = (u8)(bFactor + heartColor.b) & 0xFF;
+
+    rFactor = sHeartsEnvFactors[0][0] * factorBeating;
+    gFactor = sHeartsEnvFactors[0][1] * factorBeating;
+    bFactor = sHeartsEnvFactors[0][2] * factorBeating;
+
+    if (1) {}
+    ddType = type;
+
+    interfaceCtx->beatingHeartEnv[0] = (u8)(rFactor + heartColorBG.r) & 0xFF;
+    interfaceCtx->beatingHeartEnv[1] = (u8)(gFactor + heartColorBG.g) & 0xFF;
+    interfaceCtx->beatingHeartEnv[2] = (u8)(bFactor + heartColorBG.b) & 0xFF;
+
+    sHeartsDDPrim[0][0] = 255;
+    sHeartsDDPrim[0][1] = 255;
+    sHeartsDDPrim[0][2] = 255;
+
+    sHeartsDDEnv[0][0] = 200;
+    sHeartsDDEnv[0][1] = 0;
+    sHeartsDDEnv[0][2] = 0;
+
+    sHeartsDDPrim[1][0] = sHeartsDDPrimColors[ddType][0];
+    sHeartsDDPrim[1][1] = sHeartsDDPrimColors[ddType][1];
+    sHeartsDDPrim[1][2] = sHeartsDDPrimColors[ddType][2];
+
+    sHeartsDDEnv[1][0] = sHeartsDDEnvColors[ddType][0];
+    sHeartsDDEnv[1][1] = sHeartsDDEnvColors[ddType][1];
+    sHeartsDDEnv[1][2] = sHeartsDDEnvColors[ddType][2];
+
+    rFactor = sHeartsDDPrimFactors[ddType][0] * ddFactor;
+    gFactor = sHeartsDDPrimFactors[ddType][1] * ddFactor;
+    bFactor = sHeartsDDPrimFactors[ddType][2] * ddFactor;
+
+    sBeatingHeartsDDPrim[0] = (u8)(rFactor + 255) & 0xFF;
+    sBeatingHeartsDDPrim[1] = (u8)(gFactor + 255) & 0xFF;
+    sBeatingHeartsDDPrim[2] = (u8)(bFactor + 255) & 0xFF;
+
+    rFactor = sHeartsDDEnvFactors[ddType][0] * ddFactor;
+    gFactor = sHeartsDDEnvFactors[ddType][1] * ddFactor;
+    bFactor = sHeartsDDEnvFactors[ddType][2] * ddFactor;
+
+    sBeatingHeartsDDEnv[0] = (u8)(rFactor + 200) & 0xFF;
+    sBeatingHeartsDDEnv[1] = (u8)(gFactor + 0) & 0xFF;
+    sBeatingHeartsDDEnv[2] = (u8)(bFactor + 0) & 0xFF;
+}

--- a/src/link_color.c
+++ b/src/link_color.c
@@ -1,0 +1,774 @@
+#include "modding.h"
+#include "global.h"
+
+#include "z64player.h"
+
+// temporary OoT tunic colors
+Color_RGB8 sTunicColors[] = {
+    { 30, 105, 27 },    // PLAYER_TUNIC_KOKIRI
+    { 100, 20, 0 },     // PLAYER_TUNIC_GORON
+    { 0, 60, 100 },     // PLAYER_TUNIC_ZORA
+};
+
+Color_RGB8* humanTunicColor = &sTunicColors[0];
+
+extern Vtx object_link_childVtx_007900[];
+extern u64 gLinkHumanSkinTLUT[];
+extern u64 gLinkHumanMouthTLUT[];
+extern u64 gLinkHumanEarTex[];
+extern u64 gLinkHumanBeltTex[];
+extern u64 gLinkHumanBeltClaspTex[];
+extern u64 object_link_child_Tex_005400[];
+extern u64 object_link_child_Tex_005500[];
+extern u64 object_link_child_Tex_005540[];
+extern u64 object_link_child_Tex_005C40[];
+extern u64 object_link_child_Tex_005D40[];
+extern u64 object_link_child_Tex_005D80[];
+extern u64 object_link_child_Tex_006B00[];
+
+Gfx gLinkHumanRightThighDL[] = {
+    gsSPMatrix(0x0D000000, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW),
+    gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BACK | G_FOG | G_LIGHTING | G_SHADING_SMOOTH),
+    gsSPVertex(&object_link_childVtx_007900[80], 10, 0),
+    gsSPMatrix(0x0D000040, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW),
+    gsDPPipeSync(),
+    // gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, COMBINED, 0, SHADE, 0, 0, 0, 0, COMBINED),
+	gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, ENVIRONMENT, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPSetPrimColor(0, 0xFF, 30, 105, 27, 255),
+    gsDPSetRenderMode(G_RM_FOG_SHADE_A, G_RM_AA_ZB_OPA_SURF2),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_link_child_Tex_005D80, G_IM_FMT_I, G_IM_SIZ_8b, 8, 16, 0, G_TX_MIRROR | G_TX_WRAP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_FOG | G_LIGHTING | G_SHADING_SMOOTH),
+    gsSPVertex(&object_link_childVtx_007900[90], 21, 10),
+    gsSP2Triangles(2, 3, 10, 0, 11, 4, 5, 0),
+    gsSP2Triangles(12, 13, 6, 0, 14, 15, 7, 0),
+    gsSP2Triangles(16, 8, 6, 0, 17, 3, 0, 0),
+    gsSP2Triangles(4, 18, 19, 0, 6, 20, 21, 0),
+    gsSP2Triangles(6, 7, 22, 0, 23, 9, 4, 0),
+    gsSP2Triangles(5, 24, 25, 0, 26, 5, 2, 0),
+    gsSP2Triangles(7, 9, 27, 0, 8, 28, 1, 0),
+    gsSP1Triangle(0, 29, 30, 0),
+    gsSPVertex(&object_link_childVtx_007900[111], 9, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 0, 4, 0),
+    gsSP2Triangles(5, 6, 3, 0, 3, 7, 5, 0),
+    gsSP2Triangles(2, 4, 0, 0, 4, 7, 3, 0),
+    gsSP1Triangle(6, 5, 8, 0),
+    gsDPPipeSync(),
+    gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, PRIMITIVE, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_RGBA16),
+    gsDPLoadTLUT_pal256(gLinkHumanSkinTLUT),
+    gsDPLoadTextureBlock(object_link_child_Tex_005500, G_IM_FMT_CI, G_IM_SIZ_8b, 8, 8, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 3, G_TX_NOLOD, G_TX_NOLOD),
+    gsDPSetPrimColor(0, 0x80, 255, 255, 255, 255),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BACK | G_FOG | G_LIGHTING | G_SHADING_SMOOTH),
+    gsSPVertex(&object_link_childVtx_007900[120], 10, 0),
+    gsSP2Triangles(0, 1, 2, 0, 1, 3, 2, 0),
+    gsSP2Triangles(4, 0, 5, 0, 0, 2, 5, 0),
+    gsSP2Triangles(6, 4, 5, 0, 1, 7, 3, 0),
+    gsSP2Triangles(7, 8, 3, 0, 7, 6, 8, 0),
+    gsSP2Triangles(6, 9, 8, 0, 5, 9, 6, 0),
+    gsSPEndDisplayList(),
+};
+
+Gfx gLinkHumanLeftThighDL[] = {
+    gsSPMatrix(0x0D000000, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW),
+    gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BACK | G_FOG | G_LIGHTING | G_SHADING_SMOOTH),
+    gsSPVertex(&object_link_childVtx_007900[210], 10, 0),
+    gsSPMatrix(0x0D000100, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW),
+    gsDPPipeSync(),
+    // gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, COMBINED, 0, SHADE, 0, 0, 0, 0, COMBINED),
+	gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, ENVIRONMENT, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPSetPrimColor(0, 0xFF, 30, 105, 27, 255),
+    gsDPSetRenderMode(G_RM_FOG_SHADE_A, G_RM_AA_ZB_OPA_SURF2),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_link_child_Tex_005D80, G_IM_FMT_I, G_IM_SIZ_8b, 8, 16, 0, G_TX_MIRROR | G_TX_WRAP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_FOG | G_LIGHTING | G_SHADING_SMOOTH),
+    gsSPVertex(&object_link_childVtx_007900[220], 21, 10),
+    gsSP2Triangles(10, 5, 4, 0, 1, 0, 11, 0),
+    gsSP2Triangles(3, 12, 13, 0, 6, 14, 15, 0),
+    gsSP2Triangles(3, 2, 16, 0, 8, 5, 17, 0),
+    gsSP2Triangles(18, 19, 0, 0, 20, 21, 3, 0),
+    gsSP2Triangles(22, 6, 3, 0, 0, 7, 23, 0),
+    gsSP2Triangles(24, 25, 1, 0, 4, 1, 26, 0),
+    gsSP2Triangles(27, 7, 6, 0, 9, 28, 2, 0),
+    gsSP1Triangle(29, 30, 8, 0),
+    gsSPVertex(&object_link_childVtx_007900[241], 9, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 2, 4, 0),
+    gsSP2Triangles(4, 5, 6, 0, 6, 7, 4, 0),
+    gsSP2Triangles(2, 3, 0, 0, 4, 7, 3, 0),
+    gsSP1Triangle(8, 6, 5, 0),
+    gsDPPipeSync(),
+    gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, PRIMITIVE, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_RGBA16),
+    gsDPLoadTLUT_pal256(gLinkHumanSkinTLUT),
+    gsDPLoadTextureBlock(object_link_child_Tex_005500, G_IM_FMT_CI, G_IM_SIZ_8b, 8, 8, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 3, G_TX_NOLOD, G_TX_NOLOD),
+    gsDPSetPrimColor(0, 0x80, 255, 255, 255, 255),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BACK | G_FOG | G_LIGHTING | G_SHADING_SMOOTH),
+    gsSPVertex(&object_link_childVtx_007900[250], 10, 0),
+    gsSP2Triangles(0, 1, 2, 0, 0, 3, 1, 0),
+    gsSP2Triangles(4, 2, 5, 0, 4, 0, 2, 0),
+    gsSP2Triangles(4, 5, 6, 0, 3, 7, 1, 0),
+    gsSP2Triangles(3, 8, 7, 0, 8, 6, 7, 0),
+    gsSP2Triangles(8, 9, 6, 0, 6, 9, 4, 0),
+    gsSPEndDisplayList(),
+};
+
+Gfx gLinkHumanWaistDL[] = {
+    gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
+    gsDPPipeSync(),
+    // gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, COMBINED, 0, SHADE, 0, 0, 0, 0, COMBINED),
+	gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, ENVIRONMENT, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPSetPrimColor(0, 0xFF, 30, 105, 27, 255),
+    gsDPSetRenderMode(G_RM_FOG_SHADE_A, G_RM_AA_ZB_OPA_SURF2),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_link_child_Tex_005D80, G_IM_FMT_I, G_IM_SIZ_8b, 8, 16, 0, G_TX_MIRROR | G_TX_WRAP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_FOG | G_LIGHTING | G_SHADING_SMOOTH),
+    gsSPVertex(&object_link_childVtx_007900[260], 23, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 4, 5, 0),
+    gsSP2Triangles(3, 5, 6, 0, 5, 4, 7, 0),
+    gsSP2Triangles(7, 8, 5, 0, 9, 10, 11, 0),
+    gsSP2Triangles(2, 9, 12, 0, 9, 13, 12, 0),
+    gsSP2Triangles(10, 14, 11, 0, 4, 15, 7, 0),
+    gsSP2Triangles(6, 16, 3, 0, 17, 1, 0, 0),
+    gsSP2Triangles(15, 17, 0, 0, 2, 12, 0, 0),
+    gsSP2Triangles(0, 7, 15, 0, 11, 13, 9, 0),
+    gsSP2Triangles(12, 13, 18, 0, 19, 8, 20, 0),
+    gsSP2Triangles(20, 12, 18, 0, 20, 21, 19, 0),
+    gsSP2Triangles(20, 22, 21, 0, 8, 19, 5, 0),
+    gsSP1Triangle(18, 22, 20, 0),
+    gsDPPipeSync(),
+    gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, PRIMITIVE, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(gLinkHumanBeltClaspTex, G_IM_FMT_RGBA, G_IM_SIZ_16b, 32, 16, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 5, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsDPSetPrimColor(0, 0x80, 255, 255, 255, 255),
+    gsSPVertex(&object_link_childVtx_007900[283], 7, 0),
+    gsSP2Triangles(0, 1, 2, 0, 2, 3, 4, 0),
+    gsSP2Triangles(2, 5, 0, 0, 4, 5, 2, 0),
+    gsSP1Triangle(4, 6, 5, 0),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(gLinkHumanBeltTex, G_IM_FMT_RGBA, G_IM_SIZ_16b, 8, 16, 0, G_TX_MIRROR | G_TX_CLAMP, G_TX_MIRROR
+                         | G_TX_CLAMP, 3, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[290], 10, 0),
+    gsSP2Triangles(0, 1, 2, 0, 2, 3, 0, 0),
+    gsSP2Triangles(1, 4, 5, 0, 5, 2, 1, 0),
+    gsSP2Triangles(5, 4, 6, 0, 6, 7, 5, 0),
+    gsSP2Triangles(7, 6, 8, 0, 8, 9, 7, 0),
+    gsSPEndDisplayList(),
+};
+
+Gfx gLinkHumanCollarDL[] = {
+    gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
+    gsDPPipeSync(),
+    // gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, COMBINED, 0, SHADE, 0, 0, 0, 0, COMBINED),
+	gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, ENVIRONMENT, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPSetPrimColor(0, 0xFF, 30, 105, 27, 255),
+    gsDPSetRenderMode(G_RM_FOG_SHADE_A, G_RM_AA_ZB_OPA_SURF2),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_link_child_Tex_005D40, G_IM_FMT_I, G_IM_SIZ_8b, 8, 8, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 3, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_FOG | G_LIGHTING | G_SHADING_SMOOTH),
+    gsSPVertex(&object_link_childVtx_007900[551], 20, 0),
+    gsSP2Triangles(0, 1, 2, 0, 2, 1, 3, 0),
+    gsSP2Triangles(4, 0, 5, 0, 0, 6, 5, 0),
+    gsSP2Triangles(2, 6, 0, 0, 7, 8, 9, 0),
+    gsSP2Triangles(9, 10, 11, 0, 8, 10, 9, 0),
+    gsSP2Triangles(12, 13, 14, 0, 15, 13, 12, 0),
+    gsSP2Triangles(12, 14, 16, 0, 4, 5, 17, 0),
+    gsSP2Triangles(18, 19, 17, 0, 17, 19, 4, 0),
+    gsSPEndDisplayList(),
+};
+
+Gfx gLinkHumanTorsoDL[] = {
+    gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
+    gsDPPipeSync(),
+    // gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, COMBINED, 0, SHADE, 0, 0, 0, 0, COMBINED),
+	gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, ENVIRONMENT, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPSetPrimColor(0, 0xFF, 30, 105, 27, 255),
+    gsDPSetRenderMode(G_RM_FOG_SHADE_A, G_RM_AA_ZB_OPA_SURF2),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_link_child_Tex_005C40, G_IM_FMT_I, G_IM_SIZ_8b, 16, 16, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BACK | G_FOG | G_LIGHTING | G_SHADING_SMOOTH),
+    gsSPVertex(&object_link_childVtx_007900[819], 32, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 4, 0, 0),
+    gsSP2Triangles(5, 6, 7, 0, 8, 9, 10, 0),
+    gsSP2Triangles(11, 12, 13, 0, 1, 14, 7, 0),
+    gsSP2Triangles(4, 3, 15, 0, 10, 13, 8, 0),
+    gsSP2Triangles(14, 9, 7, 0, 16, 6, 17, 0),
+    gsSP2Triangles(16, 2, 6, 0, 18, 8, 19, 0),
+    gsSP2Triangles(18, 5, 8, 0, 20, 21, 3, 0),
+    gsSP2Triangles(20, 22, 21, 0, 0, 20, 3, 0),
+    gsSP2Triangles(2, 7, 6, 0, 5, 18, 23, 0),
+    gsSP2Triangles(2, 20, 0, 0, 2, 22, 20, 0),
+    gsSP2Triangles(2, 16, 22, 0, 17, 6, 23, 0),
+    gsSP2Triangles(6, 5, 23, 0, 7, 9, 5, 0),
+    gsSP2Triangles(11, 15, 12, 0, 15, 11, 4, 0),
+    gsSP2Triangles(8, 5, 9, 0, 10, 9, 14, 0),
+    gsSP2Triangles(7, 2, 1, 0, 19, 8, 13, 0),
+    gsSP2Triangles(13, 10, 11, 0, 24, 25, 13, 0),
+    gsSP2Triangles(26, 16, 27, 0, 28, 29, 25, 0),
+    gsSP2Triangles(29, 18, 19, 0, 30, 24, 31, 0),
+    gsSP2Triangles(12, 31, 24, 0, 18, 29, 27, 0),
+    gsSP1Triangle(23, 18, 17, 0),
+    gsSPVertex(&object_link_childVtx_007900[851], 17, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 4, 2, 0),
+    gsSP2Triangles(5, 1, 0, 0, 4, 6, 7, 0),
+    gsSP2Triangles(8, 9, 10, 0, 11, 5, 12, 0),
+    gsSP2Triangles(4, 7, 13, 0, 9, 14, 15, 0),
+    gsSP2Triangles(10, 6, 8, 0, 4, 3, 16, 0),
+    gsSP2Triangles(0, 12, 5, 0, 2, 13, 0, 0),
+    gsDPPipeSync(),
+    gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, PRIMITIVE, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_RGBA16),
+    gsDPLoadTLUT_pal256(gLinkHumanSkinTLUT),
+    gsDPLoadTextureBlock(object_link_child_Tex_005500, G_IM_FMT_CI, G_IM_SIZ_8b, 8, 8, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 3, G_TX_NOLOD, G_TX_NOLOD),
+    gsDPSetPrimColor(0, 0x80, 255, 255, 255, 255),
+    gsSPVertex(&object_link_childVtx_007900[868], 14, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 4, 5, 0),
+    gsSP2Triangles(3, 5, 6, 0, 7, 1, 8, 0),
+    gsSP2Triangles(2, 1, 7, 0, 2, 9, 0, 0),
+    gsSP2Triangles(10, 11, 12, 0, 12, 13, 10, 0),
+    gsSP2Triangles(7, 13, 12, 0, 8, 13, 7, 0),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(gLinkHumanBeltClaspTex, G_IM_FMT_RGBA, G_IM_SIZ_16b, 32, 16, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 5, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[882], 5, 0),
+    gsSP2Triangles(0, 1, 2, 0, 1, 3, 2, 0),
+    gsSP1Triangle(1, 4, 3, 0),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_link_child_Tex_006B00, G_IM_FMT_RGBA, G_IM_SIZ_16b, 16, 16, 0, G_TX_NOMIRROR |
+                         G_TX_WRAP, G_TX_MIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[887], 8, 0),
+    gsSP2Triangles(0, 1, 2, 0, 0, 2, 3, 0),
+    gsSP2Triangles(4, 5, 6, 0, 7, 5, 4, 0),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(gLinkHumanBeltTex, G_IM_FMT_RGBA, G_IM_SIZ_16b, 8, 16, 0, G_TX_MIRROR | G_TX_CLAMP, G_TX_MIRROR
+                         | G_TX_CLAMP, 3, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[895], 32, 0),
+    gsSP2Triangles(0, 1, 2, 0, 0, 2, 3, 0),
+    gsSP2Triangles(0, 3, 4, 0, 0, 4, 5, 0),
+    gsSP2Triangles(0, 6, 1, 0, 0, 7, 6, 0),
+    gsSP2Triangles(8, 9, 10, 0, 8, 11, 9, 0),
+    gsSP2Triangles(8, 12, 13, 0, 8, 13, 14, 0),
+    gsSP2Triangles(8, 14, 15, 0, 8, 10, 12, 0),
+    gsSP2Triangles(16, 17, 18, 0, 19, 16, 18, 0),
+    gsSP2Triangles(17, 20, 18, 0, 21, 19, 18, 0),
+    gsSP2Triangles(22, 23, 24, 0, 22, 24, 25, 0),
+    gsSP2Triangles(26, 22, 25, 0, 27, 28, 29, 0),
+    gsSP1Triangle(27, 30, 28, 0),
+    gsSPVertex(&object_link_childVtx_007900[926], 8, 0),
+    gsSP2Triangles(0, 1, 2, 0, 2, 1, 3, 0),
+    gsSP2Triangles(4, 5, 6, 0, 4, 7, 5, 0),
+    gsSPEndDisplayList(),
+};
+
+Gfx gLinkHumanHeadDL[] = {
+    gsSPMatrix(0x0D000440, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW),
+    gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BACK | G_FOG | G_LIGHTING | G_SHADING_SMOOTH),
+    gsSPVertex(&object_link_childVtx_007900[338], 7, 0),
+    gsSPMatrix(0x0D0001C0, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW),
+    gsDPPipeSync(),
+    gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, PRIMITIVE, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPSetRenderMode(G_RM_FOG_SHADE_A, G_RM_AA_ZB_OPA_SURF2),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_RGBA16),
+    gsDPLoadTLUT_pal256(gLinkHumanSkinTLUT),
+    gsDPLoadTextureBlock(object_link_child_Tex_005500, G_IM_FMT_CI, G_IM_SIZ_8b, 8, 8, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 3, G_TX_NOLOD, G_TX_NOLOD),
+    gsDPSetPrimColor(0, 0x80, 255, 255, 255, 255),
+    gsSPVertex(&object_link_childVtx_007900[345], 15, 7),
+    gsSP2Triangles(7, 3, 5, 0, 5, 8, 9, 0),
+    gsSP2Triangles(3, 10, 11, 0, 12, 0, 1, 0),
+    gsSP2Triangles(1, 13, 14, 0, 15, 16, 5, 0),
+    gsSP2Triangles(6, 0, 17, 0, 18, 2, 4, 0),
+    gsSP2Triangles(19, 20, 1, 0, 1, 2, 21, 0),
+    gsDPPipeSync(),
+    gsDPSetPrimColor(0, 0xFF, 255, 255, 255, 255),
+    gsDPSetTextureLUT(G_TT_RGBA16),
+    gsDPLoadTLUT_pal256(gLinkHumanSkinTLUT),
+    gsDPLoadTextureBlock(0x08000000, G_IM_FMT_CI, G_IM_SIZ_8b, 64, 32, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR |
+                         G_TX_CLAMP, 6, 5, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[360], 19, 0),
+    gsSP2Triangles(0, 1, 2, 0, 2, 3, 0, 0),
+    gsSP2Triangles(4, 0, 5, 0, 5, 0, 6, 0),
+    gsSP2Triangles(6, 0, 7, 0, 4, 1, 0, 0),
+    gsSP2Triangles(8, 1, 4, 0, 6, 9, 5, 0),
+    gsSP2Triangles(7, 10, 6, 0, 7, 0, 11, 0),
+    gsSP2Triangles(0, 3, 11, 0, 4, 5, 12, 0),
+    gsSP2Triangles(13, 12, 5, 0, 13, 5, 14, 0),
+    gsSP2Triangles(5, 9, 14, 0, 15, 10, 7, 0),
+    gsSP2Triangles(15, 7, 16, 0, 7, 17, 16, 0),
+    gsSP2Triangles(17, 7, 11, 0, 11, 3, 18, 0),
+    gsSP2Triangles(17, 11, 18, 0, 8, 4, 12, 0),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_RGBA16),
+    gsDPLoadTLUT_pal256(gLinkHumanMouthTLUT),
+    gsDPLoadTextureBlock(0x09000000, G_IM_FMT_CI, G_IM_SIZ_8b, 32, 32, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR |
+                         G_TX_CLAMP, 5, 5, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[379], 8, 0),
+    gsSP2Triangles(0, 1, 2, 0, 2, 1, 3, 0),
+    gsSP2Triangles(2, 3, 4, 0, 1, 5, 3, 0),
+    gsSP2Triangles(3, 5, 6, 0, 3, 6, 4, 0),
+    gsSP1Triangle(4, 6, 7, 0),
+    gsDPPipeSync(),
+    // gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, COMBINED, 0, SHADE, 0, 0, 0, 0, COMBINED),
+	gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, ENVIRONMENT, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPSetPrimColor(0, 0xFF, 30, 105, 27, 255),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_link_child_Tex_005D80, G_IM_FMT_I, G_IM_SIZ_8b, 8, 16, 0, G_TX_MIRROR | G_TX_WRAP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[387], 22, 0),
+    gsSP2Triangles(0, 1, 2, 0, 2, 1, 3, 0),
+    gsSP2Triangles(4, 5, 6, 0, 5, 7, 6, 0),
+    gsSP2Triangles(3, 1, 7, 0, 7, 8, 3, 0),
+    gsSP2Triangles(8, 7, 5, 0, 9, 8, 5, 0),
+    gsSP2Triangles(9, 5, 4, 0, 4, 10, 9, 0),
+    gsSP2Triangles(4, 11, 10, 0, 11, 12, 13, 0),
+    gsSP2Triangles(10, 11, 13, 0, 13, 14, 10, 0),
+    gsSP2Triangles(14, 9, 10, 0, 14, 8, 9, 0),
+    gsSP2Triangles(15, 16, 12, 0, 11, 15, 12, 0),
+    gsSP2Triangles(15, 11, 4, 0, 4, 17, 15, 0),
+    gsSP2Triangles(17, 16, 15, 0, 17, 18, 16, 0),
+    gsSP2Triangles(19, 16, 18, 0, 18, 20, 19, 0),
+    gsSP2Triangles(6, 18, 17, 0, 6, 17, 4, 0),
+    gsSP2Triangles(19, 20, 21, 0, 21, 20, 0, 0),
+    gsDPPipeSync(),
+    gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, PRIMITIVE, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_RGBA16),
+    gsDPLoadTLUT_pal256(gLinkHumanSkinTLUT),
+    gsDPLoadTextureBlock(object_link_child_Tex_005500, G_IM_FMT_CI, G_IM_SIZ_8b, 8, 8, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 3, G_TX_NOLOD, G_TX_NOLOD),
+    gsDPSetPrimColor(0, 0x80, 255, 255, 255, 255),
+    gsSPVertex(&object_link_childVtx_007900[409], 32, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 4, 5, 0),
+    gsSP2Triangles(6, 7, 8, 0, 9, 10, 11, 0),
+    gsSP2Triangles(12, 13, 14, 0, 8, 15, 6, 0),
+    gsSP2Triangles(8, 16, 17, 0, 18, 16, 8, 0),
+    gsSP2Triangles(16, 18, 19, 0, 8, 17, 20, 0),
+    gsSP2Triangles(18, 8, 7, 0, 8, 20, 15, 0),
+    gsSP2Triangles(15, 20, 21, 0, 22, 21, 23, 0),
+    gsSP2Triangles(20, 24, 21, 0, 25, 23, 26, 0),
+    gsSP2Triangles(21, 26, 23, 0, 24, 26, 21, 0),
+    gsSP2Triangles(27, 15, 21, 0, 21, 22, 27, 0),
+    gsSP2Triangles(28, 29, 30, 0, 2, 31, 0, 0),
+    gsSPVertex(&object_link_childVtx_007900[441], 6, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 4, 5, 0),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_link_child_Tex_005400, G_IM_FMT_RGBA, G_IM_SIZ_16b, 8, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[447], 32, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 4, 5, 0),
+    gsSP2Triangles(4, 3, 6, 0, 7, 8, 9, 0),
+    gsSP2Triangles(7, 10, 8, 0, 11, 10, 7, 0),
+    gsSP2Triangles(10, 11, 12, 0, 13, 14, 15, 0),
+    gsSP2Triangles(15, 14, 16, 0, 16, 17, 15, 0),
+    gsSP2Triangles(17, 16, 18, 0, 19, 20, 21, 0),
+    gsSP2Triangles(20, 22, 21, 0, 23, 24, 25, 0),
+    gsSP2Triangles(25, 24, 17, 0, 24, 26, 17, 0),
+    gsSP2Triangles(17, 26, 15, 0, 26, 27, 15, 0),
+    gsSP2Triangles(27, 13, 15, 0, 13, 27, 28, 0),
+    gsSP2Triangles(27, 26, 29, 0, 29, 28, 27, 0),
+    gsSP2Triangles(30, 28, 31, 0, 29, 31, 28, 0),
+    gsSPVertex(&object_link_childVtx_007900[479], 32, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 4, 5, 0),
+    gsSP2Triangles(6, 7, 8, 0, 9, 8, 7, 0),
+    gsSP2Triangles(8, 9, 10, 0, 11, 12, 13, 0),
+    gsSP2Triangles(10, 14, 15, 0, 16, 15, 14, 0),
+    gsSP2Triangles(15, 16, 17, 0, 18, 19, 20, 0),
+    gsSP2Triangles(21, 22, 23, 0, 22, 21, 24, 0),
+    gsSP2Triangles(25, 21, 23, 0, 23, 26, 25, 0),
+    gsSP2Triangles(21, 25, 27, 0, 28, 27, 25, 0),
+    gsSP2Triangles(28, 25, 26, 0, 28, 26, 29, 0),
+    gsSP2Triangles(29, 26, 30, 0, 29, 30, 31, 0),
+    gsSPVertex(&object_link_childVtx_007900[511], 27, 0),
+    gsSP2Triangles(0, 1, 2, 0, 0, 3, 4, 0),
+    gsSP2Triangles(5, 4, 3, 0, 3, 6, 5, 0),
+    gsSP2Triangles(5, 6, 7, 0, 8, 9, 10, 0),
+    gsSP2Triangles(11, 10, 9, 0, 12, 10, 11, 0),
+    gsSP2Triangles(13, 12, 11, 0, 14, 15, 16, 0),
+    gsSP2Triangles(17, 16, 15, 0, 18, 19, 20, 0),
+    gsSP2Triangles(21, 22, 23, 0, 21, 23, 24, 0),
+    gsSP1Triangle(25, 26, 18, 0),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_RGBA16),
+    gsDPLoadTLUT_pal256(gLinkHumanSkinTLUT),
+    gsDPLoadTextureBlock(object_link_child_Tex_005540, G_IM_FMT_CI, G_IM_SIZ_8b, 16, 16, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[538], 3, 0),
+    gsSP1Triangle(0, 1, 2, 0),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_RGBA16),
+    gsDPLoadTLUT_pal256(gLinkHumanSkinTLUT),
+    gsDPLoadTextureBlock(gLinkHumanEarTex, G_IM_FMT_CI, G_IM_SIZ_8b, 16, 16, 0, G_TX_MIRROR | G_TX_CLAMP, G_TX_MIRROR |
+                         G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[541], 10, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 0, 2, 0),
+    gsSP2Triangles(2, 4, 3, 0, 5, 6, 7, 0),
+    gsSP2Triangles(7, 8, 5, 0, 7, 9, 8, 0),
+    gsSPEndDisplayList(),
+};
+
+Gfx gLinkHumanHatDL[] = {
+    gsSPMatrix(0x0D0001C0, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW),
+    gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BACK | G_FOG | G_LIGHTING | G_SHADING_SMOOTH),
+    gsSPVertex(&object_link_childVtx_007900[300], 6, 0),
+    gsSPMatrix(0x0D000200, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW),
+    gsDPPipeSync(),
+    // gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, COMBINED, 0, SHADE, 0, 0, 0, 0, COMBINED),
+	gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, ENVIRONMENT, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPSetPrimColor(0, 0xFF, 30, 105, 27, 255),
+    gsDPSetRenderMode(G_RM_FOG_SHADE_A, G_RM_AA_ZB_OPA_SURF2),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_link_child_Tex_005D80, G_IM_FMT_I, G_IM_SIZ_8b, 8, 16, 0, G_TX_MIRROR | G_TX_WRAP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[306], 20, 6),
+    gsSP2Triangles(6, 7, 0, 0, 8, 3, 1, 0),
+    gsSP2Triangles(9, 1, 0, 0, 10, 11, 2, 0),
+    gsSP2Triangles(2, 3, 12, 0, 1, 13, 14, 0),
+    gsSP2Triangles(15, 16, 3, 0, 4, 17, 18, 0),
+    gsSP2Triangles(19, 20, 5, 0, 21, 4, 2, 0),
+    gsSP2Triangles(2, 22, 23, 0, 0, 5, 24, 0),
+    gsSP1Triangle(5, 4, 25, 0),
+    gsSPVertex(&object_link_childVtx_007900[326], 12, 0),
+    gsSP2Triangles(0, 1, 2, 0, 0, 3, 4, 0),
+    gsSP2Triangles(4, 5, 6, 0, 7, 8, 2, 0),
+    gsSP2Triangles(4, 6, 0, 0, 8, 3, 0, 0),
+    gsSP2Triangles(6, 1, 0, 0, 2, 8, 0, 0),
+    gsSP2Triangles(9, 8, 7, 0, 9, 10, 11, 0),
+    gsSP2Triangles(9, 3, 8, 0, 9, 11, 4, 0),
+    gsSP2Triangles(11, 5, 4, 0, 4, 3, 9, 0),
+    gsSP1Triangle(7, 10, 9, 0),
+    gsSPEndDisplayList(),
+};
+
+Gfx gLinkHumanRightShoulderDL[] = {
+    gsSPMatrix(0x0D000440, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW),
+    gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BACK | G_FOG | G_LIGHTING | G_SHADING_SMOOTH),
+    gsSPVertex(&object_link_childVtx_007900[745], 6, 0),
+    gsSPMatrix(0x0D000340, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW),
+    gsDPPipeSync(),
+    // gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, COMBINED, 0, SHADE, 0, 0, 0, 0, COMBINED),
+	gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, ENVIRONMENT, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPSetPrimColor(0, 0xFF, 30, 105, 27, 255),
+    gsDPSetRenderMode(G_RM_FOG_SHADE_A, G_RM_AA_ZB_OPA_SURF2),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_link_child_Tex_005C40, G_IM_FMT_I, G_IM_SIZ_8b, 16, 16, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[751], 18, 6),
+    gsSP2Triangles(0, 1, 6, 0, 7, 2, 8, 0),
+    gsSP2Triangles(9, 2, 0, 0, 3, 10, 11, 0),
+    gsSP2Triangles(3, 12, 13, 0, 4, 14, 1, 0),
+    gsSP2Triangles(15, 4, 3, 0, 16, 0, 17, 0),
+    gsSP2Triangles(5, 2, 18, 0, 0, 19, 20, 0),
+    gsSP2Triangles(21, 3, 5, 0, 22, 1, 23, 0),
+    gsSPVertex(&object_link_childVtx_007900[769], 8, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 1, 4, 0),
+    gsSP2Triangles(2, 5, 6, 0, 1, 3, 7, 0),
+    gsSP2Triangles(7, 5, 2, 0, 7, 2, 1, 0),
+    gsDPPipeSync(),
+    gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, PRIMITIVE, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_RGBA16),
+    gsDPLoadTLUT_pal256(gLinkHumanSkinTLUT),
+    gsDPLoadTextureBlock(object_link_child_Tex_005500, G_IM_FMT_CI, G_IM_SIZ_8b, 8, 8, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 3, G_TX_NOLOD, G_TX_NOLOD),
+    gsDPSetPrimColor(0, 0x80, 255, 255, 255, 255),
+    gsSPVertex(&object_link_childVtx_007900[777], 11, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 4, 5, 0),
+    gsSP2Triangles(6, 2, 7, 0, 8, 9, 1, 0),
+    gsSP2Triangles(9, 8, 4, 0, 3, 9, 4, 0),
+    gsSP2Triangles(7, 5, 6, 0, 1, 0, 8, 0),
+    gsSP2Triangles(5, 7, 3, 0, 2, 6, 0, 0),
+    gsSP2Triangles(6, 5, 10, 0, 10, 5, 4, 0),
+    gsDPPipeSync(),
+    // gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, COMBINED, 0, SHADE, 0, 0, 0, 0, COMBINED),
+	gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, ENVIRONMENT, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPSetPrimColor(0, 0xFF, 30, 105, 27, 255),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_link_child_Tex_005D40, G_IM_FMT_I, G_IM_SIZ_8b, 8, 8, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 3, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[788], 3, 0),
+    gsSP1Triangle(0, 1, 2, 0),
+    gsSPEndDisplayList(),
+};
+
+Gfx gLinkHumanLeftShoulderDL[] = {
+    gsSPMatrix(0x0D000440, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW),
+    gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BACK | G_FOG | G_LIGHTING | G_SHADING_SMOOTH),
+    gsSPVertex(&object_link_childVtx_007900[635], 6, 0),
+    gsSPMatrix(0x0D000280, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW),
+    gsDPPipeSync(),
+    // gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, COMBINED, 0, SHADE, 0, 0, 0, 0, COMBINED),
+	gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, ENVIRONMENT, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPSetPrimColor(0, 0xFF, 30, 105, 27, 255),
+    gsDPSetRenderMode(G_RM_FOG_SHADE_A, G_RM_AA_ZB_OPA_SURF2),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_link_child_Tex_005C40, G_IM_FMT_I, G_IM_SIZ_8b, 16, 16, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[641], 18, 6),
+    gsSP2Triangles(6, 4, 3, 0, 7, 5, 8, 0),
+    gsSP2Triangles(3, 5, 9, 0, 10, 11, 0, 0),
+    gsSP2Triangles(12, 13, 0, 0, 4, 14, 2, 0),
+    gsSP2Triangles(0, 2, 15, 0, 16, 3, 17, 0),
+    gsSP2Triangles(18, 5, 1, 0, 19, 20, 3, 0),
+    gsSP2Triangles(1, 0, 21, 0, 22, 4, 23, 0),
+    gsSPVertex(&object_link_childVtx_007900[659], 8, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 1, 4, 0),
+    gsSP2Triangles(5, 6, 0, 0, 7, 4, 1, 0),
+    gsSP2Triangles(0, 6, 7, 0, 1, 0, 7, 0),
+    gsDPPipeSync(),
+    gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, PRIMITIVE, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_RGBA16),
+    gsDPLoadTLUT_pal256(gLinkHumanSkinTLUT),
+    gsDPLoadTextureBlock(object_link_child_Tex_005500, G_IM_FMT_CI, G_IM_SIZ_8b, 8, 8, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 3, G_TX_NOLOD, G_TX_NOLOD),
+    gsDPSetPrimColor(0, 0x80, 255, 255, 255, 255),
+    gsSPVertex(&object_link_childVtx_007900[667], 11, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 4, 5, 0),
+    gsSP2Triangles(6, 0, 7, 0, 1, 8, 9, 0),
+    gsSP2Triangles(4, 9, 8, 0, 4, 8, 5, 0),
+    gsSP2Triangles(7, 3, 6, 0, 9, 2, 1, 0),
+    gsSP2Triangles(5, 6, 3, 0, 2, 7, 0, 0),
+    gsSP2Triangles(10, 3, 7, 0, 4, 3, 10, 0),
+    gsDPPipeSync(),
+    // gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, COMBINED, 0, SHADE, 0, 0, 0, 0, COMBINED),
+	gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, TEXEL0, ENVIRONMENT, 0, COMBINED, 0, 0, 0, 0, COMBINED),
+    gsDPSetPrimColor(0, 0xFF, 30, 105, 27, 255),
+    gsDPPipeSync(),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_link_child_Tex_005D40, G_IM_FMT_I, G_IM_SIZ_8b, 8, 8, 0, G_TX_MIRROR | G_TX_CLAMP,
+                         G_TX_MIRROR | G_TX_CLAMP, 3, 3, G_TX_NOLOD, G_TX_NOLOD),
+    gsSPVertex(&object_link_childVtx_007900[678], 3, 0),
+    gsSP1Triangle(0, 1, 2, 0),
+    gsSPEndDisplayList(),
+};
+
+void updateHumanLinkColor(PlayState* play, s32 limbIndex, Gfx** dList)
+{
+	if(limbIndex == PLAYER_LIMB_RIGHT_THIGH) {
+		*dList = gLinkHumanRightThighDL;
+	}
+	if(limbIndex == PLAYER_LIMB_LEFT_THIGH) {
+		*dList = gLinkHumanLeftThighDL;
+	}
+	if(limbIndex == PLAYER_LIMB_WAIST) {
+		*dList = gLinkHumanWaistDL;
+	}
+	if(limbIndex == PLAYER_LIMB_COLLAR) {
+		*dList = gLinkHumanCollarDL;
+	}
+	if(limbIndex == PLAYER_LIMB_TORSO) {
+		*dList = gLinkHumanTorsoDL;
+	}
+	if(limbIndex == PLAYER_LIMB_HEAD) {
+		*dList = gLinkHumanHeadDL;
+	}
+	if(limbIndex == PLAYER_LIMB_HAT) {
+		*dList = gLinkHumanHatDL;
+	}
+	if(limbIndex == PLAYER_LIMB_RIGHT_SHOULDER) {
+		*dList = gLinkHumanRightShoulderDL;
+	}
+	if(limbIndex == PLAYER_LIMB_LEFT_SHOULDER) {
+		*dList = gLinkHumanLeftShoulderDL;
+	}
+
+	OPEN_DISPS(play->state.gfxCtx);
+	gDPSetEnvColor(POLY_OPA_DISP++, humanTunicColor->r, humanTunicColor->g, humanTunicColor->b, 0);
+	CLOSE_DISPS(play->state.gfxCtx);
+}
+
+extern PlayerModelType sPlayerLeftHandType;
+extern PlayerModelType sPlayerRightHandType;
+extern s32 D_801F59E0;
+extern Gfx* gPlayerLeftHandOpenDLs[2 * PLAYER_FORM_MAX];
+extern Gfx* gPlayerLeftHandClosedDLs[2 * PLAYER_FORM_MAX];
+extern Gfx* D_801C018C[];
+extern Gfx** D_801C095C[];
+extern s32 sPlayerLod;
+extern LinkAnimationHeader gPlayerAnim_pg_punchA;
+extern struct_80124618 D_801C0750[];
+extern Gfx gLinkZoraLeftHandOpenDL[];
+extern LinkAnimationHeader gPlayerAnim_pz_gakkistart;
+extern LinkAnimationHeader gPlayerAnim_pz_gakkiplay;
+extern Gfx object_link_zora_DL_00E2A0[];
+extern Gfx** leftHandDLists;
+extern struct_80124618 D_801C0538[];
+extern struct_80124618 D_801C0560[];
+extern Gfx gLinkZoraRightHandOpenDL[];
+extern Gfx* gPlayerHandHoldingShields[2 * (PLAYER_SHIELD_MAX - 1)];
+extern Gfx* gPlayerRightHandClosedDLs[2 * PLAYER_FORM_MAX];
+extern Gfx** D_801C0964[];
+extern LinkAnimationHeader gPlayerAnim_pg_punchB;
+extern struct_80124618 D_801C0784[];
+extern Gfx* gPlayerSheathedSwords[];
+extern Gfx* gPlayerSwordSheaths[];
+
+s32 Player_OverrideLimbDrawGameplayCommon(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, Actor* thisx);
+void func_80125CE0(Player* player, struct_80124618* arg1, Vec3f* pos, Vec3s* rot);
+
+RECOMP_PATCH s32 Player_OverrideLimbDrawGameplayDefault(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot,
+                                           Actor* actor) {
+    Player* player = (Player*)actor;
+
+    if (!Player_OverrideLimbDrawGameplayCommon(play, limbIndex, dList, pos, rot, &player->actor)) {
+        // change human link's colors
+		if(player->transformation == PLAYER_FORM_HUMAN)
+		{
+			updateHumanLinkColor(play, limbIndex, dList);
+		}
+        
+        if (limbIndex == PLAYER_LIMB_LEFT_HAND) {
+            Gfx** leftHandDLists = player->leftHandDLists;
+            EquipValueSword swordEquipValue;
+
+            if (player->stateFlags3 & PLAYER_STATE3_2000) {
+                rot->z -= player->unk_B8C;
+            } else if ((sPlayerLeftHandType == PLAYER_MODELTYPE_LH_4) &&
+                       (player->stateFlags1 & PLAYER_STATE1_2000000)) {
+                leftHandDLists = &gPlayerLeftHandOpenDLs[D_801F59E0];
+                sPlayerLeftHandType = PLAYER_MODELTYPE_LH_OPEN;
+            } else if ((player->leftHandType == PLAYER_MODELTYPE_LH_OPEN) && (player->actor.speed > 2.0f) &&
+                       !(player->stateFlags1 & PLAYER_STATE1_8000000)) {
+                leftHandDLists = &gPlayerLeftHandClosedDLs[D_801F59E0];
+                sPlayerLeftHandType = PLAYER_MODELTYPE_LH_CLOSED;
+            } else if ((player->leftHandType == PLAYER_MODELTYPE_LH_ONE_HAND_SWORD) &&
+                       (player->transformation == PLAYER_FORM_HUMAN) &&
+                       ((swordEquipValue = GET_CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD),
+                         swordEquipValue != EQUIP_VALUE_SWORD_NONE))) {
+                leftHandDLists = &D_801C018C[2 * ((swordEquipValue - 1) ^ 0)];
+            } else {
+                s32 handIndex = GET_LEFT_HAND_INDEX_FROM_JOINT_TABLE(player->skelAnime.jointTable);
+
+                if (handIndex != 0) {
+                    handIndex = (handIndex >> 12) - 1;
+                    if (handIndex >= 2) {
+                        handIndex = 0;
+                    }
+                    leftHandDLists = &D_801C095C[handIndex][D_801F59E0];
+                }
+            }
+
+            *dList = leftHandDLists[sPlayerLod];
+
+            if (player->transformation == PLAYER_FORM_GORON) {
+                if (player->skelAnime.animation == &gPlayerAnim_pg_punchA) {
+                    func_80125CE0(player, D_801C0750, pos, rot);
+                }
+            } else if (player->transformation == PLAYER_FORM_ZORA) {
+                if ((player->stateFlags1 & PLAYER_STATE1_2) || (player->stateFlags1 & PLAYER_STATE1_400) ||
+                    func_801242B4(player)) {
+                    *dList = gLinkZoraLeftHandOpenDL;
+                } else {
+                    s32 phi_a1 = (player->skelAnime.animation == &gPlayerAnim_pz_gakkistart) &&
+                                 (player->skelAnime.curFrame >= 6.0f);
+
+                    if (phi_a1 || (player->skelAnime.animation == &gPlayerAnim_pz_gakkiplay)) {
+                        *dList = object_link_zora_DL_00E2A0;
+                        func_80125CE0(player, phi_a1 ? D_801C0538 : D_801C0560, pos, rot);
+                    }
+                }
+            }
+        } else if (limbIndex == PLAYER_LIMB_RIGHT_HAND) {
+            if ((player->transformation == PLAYER_FORM_ZORA) &&
+                (((player->stateFlags1 & PLAYER_STATE1_2)) || (player->stateFlags1 & PLAYER_STATE1_400) ||
+                 func_801242B4(player))) {
+                *dList = gLinkZoraRightHandOpenDL;
+            } else {
+                Gfx** rightHandDLists = player->rightHandDLists;
+
+                if (player->stateFlags3 & PLAYER_STATE3_2000) {
+                    rot->z -= player->unk_B8C;
+                }
+
+                if (sPlayerRightHandType == PLAYER_MODELTYPE_RH_SHIELD) {
+                    if (player->transformation == PLAYER_FORM_HUMAN) {
+                        if (player->currentShield != PLAYER_SHIELD_NONE) {
+                            //! FAKE
+                            rightHandDLists = &gPlayerHandHoldingShields[2 * ((player->currentShield - 1) ^ 0)];
+                        }
+                    }
+                } else if ((player->rightHandType == PLAYER_MODELTYPE_RH_OPEN) && (player->actor.speed > 2.0f) &&
+                           (!(player->stateFlags1 & PLAYER_STATE1_8000000))) {
+                    rightHandDLists = &gPlayerRightHandClosedDLs[D_801F59E0];
+                    sPlayerRightHandType = PLAYER_MODELTYPE_RH_CLOSED;
+                } else {
+                    s32 handIndex = GET_RIGHT_HAND_INDEX_FROM_JOINT_TABLE(player->skelAnime.jointTable);
+
+                    if (handIndex != 0) {
+                        handIndex = (handIndex >> 8) - 1;
+                        rightHandDLists = &D_801C0964[handIndex][D_801F59E0];
+                    }
+                }
+
+                *dList = rightHandDLists[sPlayerLod];
+                if (player->skelAnime.animation == &gPlayerAnim_pg_punchB) {
+                    func_80125CE0(player, D_801C0784, pos, rot);
+                }
+            }
+        } else if (limbIndex == PLAYER_LIMB_SHEATH) {
+            Gfx** sheathDLists = player->sheathDLists;
+
+            if (player->transformation == PLAYER_FORM_HUMAN) {
+                EquipValueSword swordEquipValue = GET_CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD);
+
+                if (swordEquipValue != EQUIP_VALUE_SWORD_NONE) {
+                    if ((player->sheathType == PLAYER_MODELTYPE_SHEATH_14) ||
+                        (player->sheathType == PLAYER_MODELTYPE_SHEATH_12)) {
+                        sheathDLists = &gPlayerSheathedSwords[2 * ((swordEquipValue - 1) ^ 0)];
+                    } else {
+                        sheathDLists = &gPlayerSwordSheaths[2 * ((swordEquipValue - 1) ^ 0)];
+                    }
+                }
+            }
+
+            *dList = sheathDLists[sPlayerLod];
+        } else if (limbIndex == PLAYER_LIMB_WAIST) {
+            *dList = player->waistDLists[sPlayerLod];
+			// not sure why the waist is reupdated here
+			if(player->transformation == PLAYER_FORM_HUMAN)
+			{
+				updateHumanLinkColor(play, limbIndex, dList);
+			}
+        } else if (limbIndex == PLAYER_LIMB_HAT) {
+            if (player->transformation == PLAYER_FORM_ZORA) {
+                Matrix_Scale((player->unk_B10[0] * 1) + 1.0f, 1.0f, 1.0f, MTXMODE_APPLY);
+            }
+        }
+    }
+
+    return false;
+}

--- a/src/magic_color.c
+++ b/src/magic_color.c
@@ -1,0 +1,104 @@
+#include "modding.h"
+#include "global.h"
+
+// set to default values for now
+Color_RGB8 magicColor = {0, 200, 0};
+Color_RGB8 magicColorChateau = {0, 0, 200};
+
+extern u64 gMagicMeterEndTex[];
+extern u64 gMagicMeterMidTex[];
+extern u64 gMagicMeterFillTex[];
+
+s16 sMagicMeterOutlinePrimRed = 255;
+s16 sMagicMeterOutlinePrimGreen = 255;
+s16 sMagicMeterOutlinePrimBlue = 255;
+
+Gfx* Gfx_DrawTexRectIA8_DropShadow(Gfx* gfx, TexturePtr texture, s16 textureWidth, s16 textureHeight, s16 rectLeft,
+                                   s16 rectTop, s16 rectWidth, s16 rectHeight, u16 dsdx, u16 dtdy, s16 r, s16 g, s16 b,
+                                   s16 a);
+Gfx* Gfx_DrawTexRectIA8_DropShadowOffset(Gfx* gfx, TexturePtr texture, s16 textureWidth, s16 textureHeight,
+                                         s16 rectLeft, s16 rectTop, s16 rectWidth, s16 rectHeight, u16 dsdx, u16 dtdy,
+                                         s16 r, s16 g, s16 b, s16 a, s32 masks, s32 rects);
+
+RECOMP_PATCH void Magic_DrawMeter(PlayState* play) {
+    InterfaceContext* interfaceCtx = &play->interfaceCtx;
+    s16 magicBarY;
+
+    OPEN_DISPS(play->state.gfxCtx);
+
+    if (gSaveContext.save.saveInfo.playerData.magicLevel != 0) {
+        if (gSaveContext.save.saveInfo.playerData.healthCapacity > 0xA0) {
+            magicBarY = 42; // two rows of hearts
+        } else {
+            magicBarY = 34; // one row of hearts
+        }
+
+        Gfx_SetupDL39_Overlay(play->state.gfxCtx);
+
+        gDPSetEnvColor(OVERLAY_DISP++, 100, 50, 50, 255);
+
+        OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadow(
+            OVERLAY_DISP, gMagicMeterEndTex, 8, 16, 18, magicBarY, 8, 16, 1 << 10, 1 << 10, sMagicMeterOutlinePrimRed,
+            sMagicMeterOutlinePrimGreen, sMagicMeterOutlinePrimBlue, interfaceCtx->magicAlpha);
+        OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadow(OVERLAY_DISP, gMagicMeterMidTex, 24, 16, 26, magicBarY,
+                                                     ((void)0, gSaveContext.magicCapacity), 16, 1 << 10, 1 << 10,
+                                                     sMagicMeterOutlinePrimRed, sMagicMeterOutlinePrimGreen,
+                                                     sMagicMeterOutlinePrimBlue, interfaceCtx->magicAlpha);
+        OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadowOffset(
+            OVERLAY_DISP, gMagicMeterEndTex, 8, 16, ((void)0, gSaveContext.magicCapacity) + 26, magicBarY, 8, 16,
+            1 << 10, 1 << 10, sMagicMeterOutlinePrimRed, sMagicMeterOutlinePrimGreen, sMagicMeterOutlinePrimBlue,
+            interfaceCtx->magicAlpha, 3, 0x100);
+
+        gDPPipeSync(OVERLAY_DISP++);
+        gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, 0, 0, 0, PRIMITIVE, PRIMITIVE,
+                          ENVIRONMENT, TEXEL0, ENVIRONMENT, 0, 0, 0, PRIMITIVE);
+        gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
+
+        if (gSaveContext.magicState == MAGIC_STATE_METER_FLASH_2) {
+            // Yellow part of the meter indicating the amount of magic to be subtracted
+            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 250, 250, 0, interfaceCtx->magicAlpha);
+            gDPLoadTextureBlock_4b(OVERLAY_DISP++, gMagicMeterFillTex, G_IM_FMT_I, 16, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                                   G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+            gSPTextureRectangle(OVERLAY_DISP++, 104, (magicBarY + 3) << 2,
+                                (((void)0, gSaveContext.save.saveInfo.playerData.magic) + 26) << 2,
+                                (magicBarY + 10) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+
+            // Fill the rest of the meter with the normal magic color
+            gDPPipeSync(OVERLAY_DISP++);
+            if (CHECK_WEEKEVENTREG(WEEKEVENTREG_DRANK_CHATEAU_ROMANI)) {
+                // Blue magic
+				// gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 0, 200, interfaceCtx->magicAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, magicColorChateau.r, magicColorChateau.g, magicColorChateau.b, interfaceCtx->magicAlpha);
+            } else {
+                // Green magic (default)
+				// gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 200, 0, interfaceCtx->magicAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, magicColor.r, magicColor.g, magicColor.b, interfaceCtx->magicAlpha);
+            }
+
+            gSPTextureRectangle(
+                OVERLAY_DISP++, 104, (magicBarY + 3) << 2,
+                ((((void)0, gSaveContext.save.saveInfo.playerData.magic) - ((void)0, gSaveContext.magicToConsume)) + 26)
+                    << 2,
+                (magicBarY + 10) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+        } else {
+            // Fill the whole meter with the normal magic color
+            if (CHECK_WEEKEVENTREG(WEEKEVENTREG_DRANK_CHATEAU_ROMANI)) {
+                // Blue magic
+				// gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 0, 200, interfaceCtx->magicAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, magicColorChateau.r, magicColorChateau.g, magicColorChateau.b, interfaceCtx->magicAlpha);
+            } else {
+                // Green magic (default)
+				// gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 200, 0, interfaceCtx->magicAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, magicColor.r, magicColor.g, magicColor.b, interfaceCtx->magicAlpha);
+            }
+
+            gDPLoadTextureBlock_4b(OVERLAY_DISP++, gMagicMeterFillTex, G_IM_FMT_I, 16, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                                   G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+            gSPTextureRectangle(OVERLAY_DISP++, 104, (magicBarY + 3) << 2,
+                                (((void)0, gSaveContext.save.saveInfo.playerData.magic) + 26) << 2,
+                                (magicBarY + 10) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+        }
+    }
+
+    CLOSE_DISPS(play->state.gfxCtx);
+}

--- a/src/pause_color.c
+++ b/src/pause_color.c
@@ -1,0 +1,828 @@
+#include "modding.h"
+#include "global.h"
+
+// set to default values for now
+Color_RGB8 pauseMainColor = {180, 180, 120};
+Color_RGB8 pauseExtraColor = {150, 140, 90};
+
+#define IS_PAUSE_STATE_GAMEOVER \
+    ((pauseCtx->state >= PAUSE_STATE_GAMEOVER_0) && (pauseCtx->state <= PAUSE_STATE_GAMEOVER_10))
+
+typedef enum {
+    /* 0x00 */ PAUSE_STATE_OFF,
+    /* 0x01 */ PAUSE_STATE_OPENING_0,
+    /* 0x02 */ PAUSE_STATE_OPENING_1,
+    /* 0x03 */ PAUSE_STATE_OPENING_2,
+    /* 0x04 */ PAUSE_STATE_OPENING_3,
+    /* 0x05 */ PAUSE_STATE_OPENING_4,
+    /* 0x06 */ PAUSE_STATE_MAIN, // Pause menu ready for player inputs.
+    /* 0x07 */ PAUSE_STATE_SAVEPROMPT,
+    /* 0x08 */ PAUSE_STATE_GAMEOVER_0,
+    /* 0x09 */ PAUSE_STATE_GAMEOVER_1,
+    /* 0x0A */ PAUSE_STATE_GAMEOVER_2,
+    /* 0x0B */ PAUSE_STATE_GAMEOVER_3,
+    /* 0x0C */ PAUSE_STATE_GAMEOVER_4,
+    /* 0x0D */ PAUSE_STATE_GAMEOVER_5,
+    /* 0x0E */ PAUSE_STATE_GAMEOVER_SAVE_PROMPT,
+    /* 0x0F */ PAUSE_STATE_GAMEOVER_7,
+    /* 0x10 */ PAUSE_STATE_GAMEOVER_8,
+    /* 0x11 */ PAUSE_STATE_GAMEOVER_CONTINUE_PROMPT,
+    /* 0x12 */ PAUSE_STATE_GAMEOVER_10,
+    /* 0x13 */ PAUSE_STATE_OWLWARP_0,
+    /* 0x14 */ PAUSE_STATE_OWLWARP_1,
+    /* 0x15 */ PAUSE_STATE_OWLWARP_2,
+    /* 0x16 */ PAUSE_STATE_OWLWARP_3,
+    /* 0x17 */ PAUSE_STATE_OWLWARP_SELECT, // Selecting the destination
+    /* 0x18 */ PAUSE_STATE_OWLWARP_CONFIRM, // Confirming the choice given
+    /* 0x19 */ PAUSE_STATE_OWLWARP_6,
+    /* 0x1A */ PAUSE_STATE_UNPAUSE_SETUP, // Unpause
+    /* 0x1B */ PAUSE_STATE_UNPAUSE_CLOSE
+} PauseState;
+
+s16 sGameOverPrimR = 0;
+s16 sGameOverPrimG = 0;
+s16 sGameOverPrimB = 0;
+s16 sGameOverPrimAlpha = 255;
+// s16 sCursorPrimR = 0;
+// s16 sCursorPrimG = 0;
+// s16 sCursorPrimB = 0;
+// s16 sCursorEnvR = 0;
+// s16 sCursorEnvG = 0;
+// s16 sCursorEnvB = 0;
+extern s16 sCursorPrimR;
+extern s16 sCursorPrimG;
+extern s16 sCursorPrimB;
+extern s16 sCursorEnvR;
+extern s16 sCursorEnvG;
+extern s16 sCursorEnvB;
+s16 sGameOverEnvR = 255;
+s16 sGameOverEnvG = 0;
+s16 sGameOverEnvB = 0;
+// TODO: add cursor colors
+s16 sCursorPrimColorTarget[][3] = {
+    { 255, 255, 255 }, { 255, 255, 255 }, { 255, 255, 0 }, { 255, 255, 0 }, { 100, 150, 255 }, { 100, 255, 255 },
+};
+s16 sCursorEnvColorTarget[][3] = {
+    { 0, 0, 0 }, { 170, 170, 170 }, { 0, 0, 0 }, { 255, 160, 0 }, { 0, 0, 100 }, { 0, 150, 255 },
+};
+
+typedef enum {
+    /* 0 */ PAUSE_ITEM,
+    /* 1 */ PAUSE_MAP,
+    /* 2 */ PAUSE_QUEST,
+    /* 3 */ PAUSE_MASK,
+    /* 4 */ PAUSE_WORLD_MAP
+} PauseMenuPage;
+
+f32 sPauseMenuVerticalOffset = 0.0f;
+f32 D_8082B90C = 0.0f;
+f32 sPauseCursorLeftMoveOffsetX = 40.0f;
+f32 sPauseCursorRightMoveOffsetX = -40.0f;
+
+extern s16 sPauseCursorLeftX;
+extern s16 sPauseCursorRightX;
+
+s16 D_8082B920 = 10;
+
+s16 sPauseZRCursorColorTimerInits[] = { 20, 4, 20, 10 };
+
+extern TexturePtr sItemPageBgTextures[];
+extern TexturePtr sMapPageBgTextures[];
+extern TexturePtr sQuestPageBgTextures[];
+extern TexturePtr sMaskPageBgTextures[];
+extern s16 sInDungeonScene;
+
+typedef enum {
+    /* 0x00 */ PAUSE_MAIN_STATE_IDLE, // Await input for the next action
+    /* 0x01 */ PAUSE_MAIN_STATE_SWITCHING_PAGE,
+    /* 0x02 */ PAUSE_MAIN_STATE_SONG_PLAYBACK,
+    /* 0x03 */ PAUSE_MAIN_STATE_EQUIP_ITEM,
+    /* 0x04 */ PAUSE_MAIN_STATE_SONG_PROMPT_INIT,
+    /* 0x05 */ PAUSE_MAIN_STATE_SONG_PROMPT,
+    /* 0x06 */ PAUSE_MAIN_STATE_SONG_PROMPT_DONE,
+    /* 0x07 */ PAUSE_MAIN_STATE_SONG_PROMPT_UNUSED,
+    /* 0x08 */ PAUSE_MAIN_STATE_IDLE_CURSOR_ON_SONG, // Await input but the cursor is on a song
+    /* 0x09 */ PAUSE_MAIN_STATE_SONG_PLAYBACK_INIT,
+    /* 0x0F */ PAUSE_MAIN_STATE_EQUIP_MASK = 0xF,
+    /* 0x10 */ PAUSE_MAIN_STATE_BOMBERS_NOTEBOOK_OPEN,
+    /* 0x11 */ PAUSE_MAIN_STATE_UNK
+} PauseMainState;
+
+typedef enum {
+    /* 0x00 */ PAUSE_SAVEPROMPT_STATE_APPEARING,
+    /* 0x01 */ PAUSE_SAVEPROMPT_STATE_1,
+    /* 0x02 */ PAUSE_SAVEPROMPT_STATE_RETURN_TO_MENU,
+    /* 0x03 */ PAUSE_SAVEPROMPT_STATE_3,
+    /* 0x04 */ PAUSE_SAVEPROMPT_STATE_4,
+    /* 0x05 */ PAUSE_SAVEPROMPT_STATE_5,
+    /* 0x06 */ PAUSE_SAVEPROMPT_STATE_6,
+    /* 0x07 */ PAUSE_SAVEPROMPT_STATE_7
+} PauseSavePromptState;
+
+Gfx* KaleidoScope_DrawPageSections(Gfx* gfx, Vtx* vertices, TexturePtr* textures);
+void KaleidoScope_DrawItemSelect(PlayState* play);
+void KaleidoScope_DrawDungeonMap(PlayState* play);
+void KaleidoScope_DrawWorldMap(PlayState* play);
+void KaleidoScope_DrawQuestStatus(PlayState* play);
+void KaleidoScope_DrawMaskSelect(PlayState* play);
+
+RECOMP_PATCH void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
+    static s16 sCursorColorTimer = 10;
+    static s16 sCursorColorTargetIndex = 0;
+    PauseContext* pauseCtx = &play->pauseCtx;
+    s16 stepR;
+    s16 stepG;
+    s16 stepB;
+
+    OPEN_DISPS(gfxCtx);
+
+    if (!IS_PAUSE_STATE_GAMEOVER) {
+        if (pauseCtx->state != PAUSE_STATE_SAVEPROMPT) {
+
+            stepR =
+                ABS_ALT(sCursorPrimR - sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0]) /
+                sCursorColorTimer;
+            stepG =
+                ABS_ALT(sCursorPrimG - sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1]) /
+                sCursorColorTimer;
+            stepB =
+                ABS_ALT(sCursorPrimB - sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2]) /
+                sCursorColorTimer;
+
+            if (sCursorPrimR >= sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0]) {
+                sCursorPrimR -= stepR;
+            } else {
+                sCursorPrimR += stepR;
+            }
+
+            if (sCursorPrimG >= sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1]) {
+                sCursorPrimG -= stepG;
+            } else {
+                sCursorPrimG += stepG;
+            }
+
+            if (sCursorPrimB >= sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2]) {
+                sCursorPrimB -= stepB;
+            } else {
+                sCursorPrimB += stepB;
+            }
+
+            stepR =
+                ABS_ALT(sCursorEnvR - sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0]) /
+                sCursorColorTimer;
+            stepG =
+                ABS_ALT(sCursorEnvG - sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1]) /
+                sCursorColorTimer;
+            stepB =
+                ABS_ALT(sCursorEnvB - sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2]) /
+                sCursorColorTimer;
+
+            if (sCursorEnvR >= sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0]) {
+                sCursorEnvR -= stepR;
+            } else {
+                sCursorEnvR += stepR;
+            }
+
+            if (sCursorEnvG >= sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1]) {
+                sCursorEnvG -= stepG;
+            } else {
+                sCursorEnvG += stepG;
+            }
+
+            if (sCursorEnvB >= sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2]) {
+                sCursorEnvB -= stepB;
+            } else {
+                sCursorEnvB += stepB;
+            }
+
+            sCursorColorTimer--;
+            if (sCursorColorTimer == 0) {
+                sCursorPrimR = sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0];
+                sCursorPrimG = sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1];
+                sCursorPrimB = sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2];
+                sCursorEnvR = sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0];
+                sCursorEnvG = sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1];
+                sCursorEnvB = sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2];
+                sCursorColorTargetIndex ^= 1;
+                sCursorColorTimer = 10;
+            }
+        }
+
+        if ((pauseCtx->pageIndex != PAUSE_ITEM) && (pauseCtx->pageIndex != PAUSE_QUEST)) {
+            gDPPipeSync(POLY_OPA_DISP++);
+
+            gDPSetCombineLERP(POLY_OPA_DISP++, TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0, SHADE, 0, TEXEL0, 0, PRIMITIVE, 0,
+                              TEXEL0, 0, SHADE, 0);
+
+            // gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
+			gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, pauseMainColor.r, pauseMainColor.g, pauseMainColor.b, 255);
+
+
+            Matrix_RotateYF(0.0f, MTXMODE_NEW);
+            Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
+            Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
+            Matrix_RotateXFApply(-pauseCtx->itemPageRoll / 100.0f);
+
+            gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+            POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->itemPageVtx, sItemPageBgTextures);
+
+            KaleidoScope_DrawItemSelect(play);
+        }
+
+        if ((pauseCtx->pageIndex != PAUSE_MAP) && (pauseCtx->pageIndex != PAUSE_MASK)) {
+            gDPPipeSync(POLY_OPA_DISP++);
+
+            gDPSetCombineLERP(POLY_OPA_DISP++, TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0, SHADE, 0, TEXEL0, 0, PRIMITIVE, 0,
+                              TEXEL0, 0, SHADE, 0);
+
+            // gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
+			gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, pauseMainColor.r, pauseMainColor.g, pauseMainColor.b, 255);
+
+
+            Matrix_RotateYF(-1.57f, MTXMODE_NEW);
+            Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
+            Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
+            Matrix_RotateXFApply(-pauseCtx->mapPageRoll / 100.0f);
+
+            gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+            POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->mapPageVtx, sMapPageBgTextures);
+
+            if (sInDungeonScene) {
+                KaleidoScope_DrawDungeonMap(play);
+                Gfx_SetupDL42_Opa(gfxCtx);
+                gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
+                func_801091F0(play);
+            } else {
+                KaleidoScope_DrawWorldMap(play);
+            }
+        }
+
+        if ((pauseCtx->pageIndex != PAUSE_QUEST) && (pauseCtx->pageIndex != PAUSE_ITEM)) {
+            gDPPipeSync(POLY_OPA_DISP++);
+
+            gDPSetTextureFilter(POLY_OPA_DISP++, G_TF_BILERP);
+
+            gDPSetCombineLERP(POLY_OPA_DISP++, TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0, SHADE, 0, TEXEL0, 0, PRIMITIVE, 0,
+                              TEXEL0, 0, SHADE, 0);
+
+            // gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
+			gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, pauseMainColor.r, pauseMainColor.g, pauseMainColor.b, 255);
+
+
+            Matrix_RotateYF(-3.14f, MTXMODE_NEW);
+            Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
+            Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
+            Matrix_RotateXFApply(-pauseCtx->questPageRoll / 100.0f);
+
+            gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+            POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->questPageVtx, sQuestPageBgTextures);
+
+            KaleidoScope_DrawQuestStatus(play);
+        }
+
+        if ((pauseCtx->pageIndex != PAUSE_MASK) && (pauseCtx->pageIndex != PAUSE_MAP)) {
+            gDPPipeSync(POLY_OPA_DISP++);
+
+            gDPSetTextureFilter(POLY_OPA_DISP++, G_TF_BILERP);
+
+            gDPSetCombineLERP(POLY_OPA_DISP++, TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0, SHADE, 0, TEXEL0, 0, PRIMITIVE, 0,
+                              TEXEL0, 0, SHADE, 0);
+
+            // gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
+			gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, pauseMainColor.r, pauseMainColor.g, pauseMainColor.b, 255);
+
+
+            Matrix_RotateYF(1.57f, MTXMODE_NEW);
+            Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
+            Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
+            Matrix_RotateXFApply(-pauseCtx->maskPageRoll / 100.0f);
+
+            gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+            POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->maskPageVtx, sMaskPageBgTextures);
+
+            KaleidoScope_DrawMaskSelect(play);
+        }
+
+        switch (pauseCtx->pageIndex) {
+            case PAUSE_ITEM:
+                if (pauseCtx->mainState <= PAUSE_MAIN_STATE_EQUIP_MASK) {
+                    gDPPipeSync(POLY_OPA_DISP++);
+
+                    gDPSetCombineLERP(POLY_OPA_DISP++, TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0, SHADE, 0, TEXEL0, 0,
+                                      PRIMITIVE, 0, TEXEL0, 0, SHADE, 0);
+
+                    // gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
+					gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, pauseMainColor.r, pauseMainColor.g, pauseMainColor.b, 255);
+
+
+                    Matrix_RotateYF(0.0f, MTXMODE_NEW);
+                    Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
+                    Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
+                    Matrix_RotateXFApply(-pauseCtx->itemPageRoll / 100.0f);
+
+                    gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+                    POLY_OPA_DISP =
+                        KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->itemPageVtx, sItemPageBgTextures);
+
+                    KaleidoScope_DrawItemSelect(play);
+                }
+                break;
+
+            case PAUSE_MAP:
+                gDPPipeSync(POLY_OPA_DISP++);
+
+                gDPSetCombineLERP(POLY_OPA_DISP++, TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0, SHADE, 0, TEXEL0, 0, PRIMITIVE,
+                                  0, TEXEL0, 0, SHADE, 0);
+
+                // gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
+				gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, pauseMainColor.r, pauseMainColor.g, pauseMainColor.b, 255);
+
+
+                Matrix_RotateYF(-1.57f, MTXMODE_NEW);
+                Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
+                Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
+                Matrix_RotateXFApply(-pauseCtx->mapPageRoll / 100.0f);
+
+                gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+                POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->mapPageVtx, sMapPageBgTextures);
+
+                if (sInDungeonScene) {
+                    KaleidoScope_DrawDungeonMap(play);
+                    Gfx_SetupDL42_Opa(gfxCtx);
+
+                    gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
+
+                    func_801091F0(play);
+                } else {
+                    Matrix_RotateYF(R_PAUSE_WORLD_MAP_YAW / 1000.0f, MTXMODE_NEW);
+
+                    if ((pauseCtx->state == PAUSE_STATE_OPENING_3) || (pauseCtx->state == PAUSE_STATE_OWLWARP_3) ||
+                        (pauseCtx->state >= PAUSE_STATE_OWLWARP_6) ||
+                        ((pauseCtx->state == PAUSE_STATE_SAVEPROMPT) &&
+                         ((pauseCtx->savePromptState == PAUSE_SAVEPROMPT_STATE_3) ||
+                          (pauseCtx->savePromptState == PAUSE_SAVEPROMPT_STATE_7)))) {
+                        Matrix_Translate(0.0f, (R_PAUSE_WORLD_MAP_Y_OFFSET - 8000) / 100.0f,
+                                         R_PAUSE_WORLD_MAP_DEPTH / 100.0f, MTXMODE_APPLY);
+                    } else {
+                        Matrix_Translate(0.0f, R_PAUSE_WORLD_MAP_Y_OFFSET / 100.0f, R_PAUSE_WORLD_MAP_DEPTH / 100.0f,
+                                         MTXMODE_APPLY);
+                    }
+
+                    Matrix_Scale(1.0f, 1.0f, 1.0f, MTXMODE_APPLY);
+                    Matrix_RotateXFApply(-pauseCtx->mapPageRoll / 100.0f);
+
+                    gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+                    KaleidoScope_DrawWorldMap(play);
+                }
+                break;
+
+            case PAUSE_QUEST:
+                gDPPipeSync(POLY_OPA_DISP++);
+
+                gDPSetCombineLERP(POLY_OPA_DISP++, TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0, SHADE, 0, TEXEL0, 0, PRIMITIVE,
+                                  0, TEXEL0, 0, SHADE, 0);
+
+                // gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
+				gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, pauseMainColor.r, pauseMainColor.g, pauseMainColor.b, 255);
+
+
+                gDPSetTextureFilter(POLY_OPA_DISP++, G_TF_BILERP);
+
+                Matrix_RotateYF(-3.14f, MTXMODE_NEW);
+                Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
+                Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
+                Matrix_RotateXFApply(-pauseCtx->questPageRoll / 100.0f);
+
+                gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+                POLY_OPA_DISP =
+                    KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->questPageVtx, sQuestPageBgTextures);
+
+                KaleidoScope_DrawQuestStatus(play);
+                break;
+
+            case PAUSE_MASK:
+                gDPPipeSync(POLY_OPA_DISP++);
+
+                gDPSetCombineLERP(POLY_OPA_DISP++, TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0, SHADE, 0, TEXEL0, 0, PRIMITIVE,
+                                  0, TEXEL0, 0, SHADE, 0);
+
+                // gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
+				gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, pauseMainColor.r, pauseMainColor.g, pauseMainColor.b, 255);
+
+
+                Matrix_RotateYF(1.57f, MTXMODE_NEW);
+                Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
+                Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
+                Matrix_RotateXFApply(-pauseCtx->maskPageRoll / 100.0f);
+
+                gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+                POLY_OPA_DISP =
+                    KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->maskPageVtx, sMaskPageBgTextures);
+
+                KaleidoScope_DrawMaskSelect(play);
+                break;
+        }
+    }
+
+    CLOSE_DISPS(gfxCtx);
+}
+
+extern TexturePtr D_8082B998[];
+extern TexturePtr D_8082B9A8[];
+
+#define PAUSE_CURSOR_PAGE_LEFT 10
+#define PAUSE_CURSOR_PAGE_RIGHT 11
+
+extern Gfx gItemNamePanelDL[];
+extern Gfx gZButtonIconDL[];
+extern Gfx gRButtonIconDL[];
+extern Gfx gAButtonIconDL[];
+extern Gfx gCButtonIconsDL[];
+
+extern u64 gPauseToDecideENGTex[];
+extern u64 gPauseToEquipENGTex[];
+extern u64 gPauseToViewNotebookENGTex[];
+extern u64 gPauseToPlayMelodyENGTex[];
+
+#define PAUSE_NAME_COLOR_SET_WHITE 0
+#define PAUSE_NAME_COLOR_SET_GREY 1
+#define PAUSE_ITEM_NONE 999
+
+RECOMP_PATCH void KaleidoScope_DrawInfoPanel(PlayState* play) {
+    static s16 sPauseZRCursorColorTargets[][4] = {
+        { 180, 210, 255, 220 },
+        { 100, 100, 150, 220 },
+    };
+    static s16 sPauseZRCursorColorTimer = 20;
+    static s16 sPauseZRCursorColorIndex = 0;
+    static s16 sPauseZRCursorRed;
+    static s16 sPauseZRCursorGreen;
+    static s16 sPauseZRCursorBlue;
+    static s16 sPauseZRCursorAlpha;
+    PauseContext* pauseCtx = &play->pauseCtx;
+    s16 stepR;
+    s16 stepG;
+    s16 stepB;
+    s16 stepA;
+    s16 y;
+    s16 i;
+    s16 j;
+
+    OPEN_DISPS(play->state.gfxCtx);
+
+    stepR =
+        ABS_ALT(sPauseZRCursorRed - sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][0]) / sPauseZRCursorColorTimer;
+    stepG = ABS_ALT(sPauseZRCursorGreen - sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][1]) /
+            sPauseZRCursorColorTimer;
+    stepB = ABS_ALT(sPauseZRCursorBlue - sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][2]) /
+            sPauseZRCursorColorTimer;
+    stepA = ABS_ALT(sPauseZRCursorAlpha - sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][3]) /
+            sPauseZRCursorColorTimer;
+
+    if (sPauseZRCursorRed >= sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][0]) {
+        sPauseZRCursorRed -= stepR;
+    } else {
+        sPauseZRCursorRed += stepR;
+    }
+
+    if (sPauseZRCursorGreen >= sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][1]) {
+        sPauseZRCursorGreen -= stepG;
+    } else {
+        sPauseZRCursorGreen += stepG;
+    }
+
+    if (sPauseZRCursorBlue >= sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][2]) {
+        sPauseZRCursorBlue -= stepB;
+    } else {
+        sPauseZRCursorBlue += stepB;
+    }
+
+    if (sPauseZRCursorAlpha >= sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][3]) {
+        sPauseZRCursorAlpha -= stepA;
+    } else {
+        sPauseZRCursorAlpha += stepA;
+    }
+
+    sPauseZRCursorColorTimer--;
+    if (sPauseZRCursorColorTimer == 0) {
+        sPauseZRCursorRed = sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][0];
+        sPauseZRCursorGreen = sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][1];
+        sPauseZRCursorBlue = sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][2];
+        sPauseZRCursorAlpha = sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][3];
+        sPauseZRCursorColorTimer = sPauseZRCursorColorTimerInits[0];
+        sPauseZRCursorColorIndex ^= 1;
+    }
+
+    y = pauseCtx->infoPanelOffsetY - 76;
+    for (j = 0, i = 0; i < 7; i++, j += 4) {
+        pauseCtx->infoPanelVtx[j + 0].v.ob[0] = pauseCtx->infoPanelVtx[j + 2].v.ob[0] = -72;
+
+        pauseCtx->infoPanelVtx[j + 1].v.ob[0] = pauseCtx->infoPanelVtx[j + 3].v.ob[0] = 0;
+
+        pauseCtx->infoPanelVtx[j + 0].v.ob[1] = pauseCtx->infoPanelVtx[j + 1].v.ob[1] = y;
+
+        pauseCtx->infoPanelVtx[j + 2].v.ob[1] = pauseCtx->infoPanelVtx[j + 3].v.ob[1] = y - 24;
+
+        pauseCtx->infoPanelVtx[j + 0].v.ob[2] = pauseCtx->infoPanelVtx[j + 1].v.ob[2] =
+            pauseCtx->infoPanelVtx[j + 2].v.ob[2] = pauseCtx->infoPanelVtx[j + 3].v.ob[2] = 0;
+
+        pauseCtx->infoPanelVtx[j + 0].v.flag = pauseCtx->infoPanelVtx[j + 1].v.flag =
+            pauseCtx->infoPanelVtx[j + 2].v.flag = pauseCtx->infoPanelVtx[j + 3].v.flag = 0;
+
+        pauseCtx->infoPanelVtx[j + 0].v.tc[0] = pauseCtx->infoPanelVtx[j + 0].v.tc[1] =
+            pauseCtx->infoPanelVtx[j + 1].v.tc[1] = pauseCtx->infoPanelVtx[j + 2].v.tc[0] = 0;
+
+        pauseCtx->infoPanelVtx[j + 1].v.tc[0] = pauseCtx->infoPanelVtx[j + 3].v.tc[0] = 72 * (1 << 5);
+
+        pauseCtx->infoPanelVtx[j + 2].v.tc[1] = pauseCtx->infoPanelVtx[j + 3].v.tc[1] = 24 * (1 << 5);
+
+        pauseCtx->infoPanelVtx[j + 0].v.cn[0] = pauseCtx->infoPanelVtx[j + 2].v.cn[0] =
+            pauseCtx->infoPanelVtx[j + 0].v.cn[1] = pauseCtx->infoPanelVtx[j + 2].v.cn[1] =
+                pauseCtx->infoPanelVtx[j + 0].v.cn[2] = pauseCtx->infoPanelVtx[j + 2].v.cn[2] =
+                    pauseCtx->infoPanelVtx[j + 1].v.cn[0] = pauseCtx->infoPanelVtx[j + 3].v.cn[0] =
+                        pauseCtx->infoPanelVtx[j + 1].v.cn[1] = pauseCtx->infoPanelVtx[j + 3].v.cn[1] =
+                            pauseCtx->infoPanelVtx[j + 1].v.cn[2] = pauseCtx->infoPanelVtx[j + 3].v.cn[2] = 200;
+
+        pauseCtx->infoPanelVtx[j + 0].v.cn[3] = pauseCtx->infoPanelVtx[j + 2].v.cn[3] =
+            pauseCtx->infoPanelVtx[j + 1].v.cn[3] = pauseCtx->infoPanelVtx[j + 3].v.cn[3] = pauseCtx->alpha;
+    }
+
+    pauseCtx->infoPanelVtx[4].v.ob[0] = pauseCtx->infoPanelVtx[6].v.ob[0] = pauseCtx->infoPanelVtx[0].v.ob[0] + 72;
+
+    pauseCtx->infoPanelVtx[5].v.ob[0] = pauseCtx->infoPanelVtx[7].v.ob[0] = pauseCtx->infoPanelVtx[4].v.ob[0] + 72;
+
+    if ((pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) && (pauseCtx->mainState == PAUSE_MAIN_STATE_IDLE)) {
+        pauseCtx->infoPanelVtx[8].v.ob[0] = pauseCtx->infoPanelVtx[10].v.ob[0] = sPauseCursorLeftX;
+
+        pauseCtx->infoPanelVtx[9].v.ob[0] = pauseCtx->infoPanelVtx[11].v.ob[0] = pauseCtx->infoPanelVtx[8].v.ob[0] + 24;
+
+        pauseCtx->infoPanelVtx[8].v.ob[1] = pauseCtx->infoPanelVtx[9].v.ob[1] = D_8082B920;
+
+        pauseCtx->infoPanelVtx[10].v.ob[1] = pauseCtx->infoPanelVtx[11].v.ob[1] =
+            pauseCtx->infoPanelVtx[8].v.ob[1] - 32;
+    } else {
+        pauseCtx->infoPanelVtx[8].v.ob[0] = pauseCtx->infoPanelVtx[10].v.ob[0] = sPauseCursorLeftX + 3;
+
+        pauseCtx->infoPanelVtx[9].v.ob[0] = pauseCtx->infoPanelVtx[11].v.ob[0] = pauseCtx->infoPanelVtx[8].v.ob[0] + 18;
+
+        pauseCtx->infoPanelVtx[8].v.ob[1] = pauseCtx->infoPanelVtx[9].v.ob[1] = D_8082B920 - 3;
+
+        pauseCtx->infoPanelVtx[10].v.ob[1] = pauseCtx->infoPanelVtx[11].v.ob[1] =
+            pauseCtx->infoPanelVtx[8].v.ob[1] - 26;
+    }
+
+    if ((pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_RIGHT) && (pauseCtx->mainState == PAUSE_MAIN_STATE_IDLE)) {
+        pauseCtx->infoPanelVtx[12].v.ob[0] = pauseCtx->infoPanelVtx[14].v.ob[0] = sPauseCursorRightX;
+
+        pauseCtx->infoPanelVtx[13].v.ob[0] = pauseCtx->infoPanelVtx[15].v.ob[0] =
+            pauseCtx->infoPanelVtx[12].v.ob[0] + 24;
+
+        pauseCtx->infoPanelVtx[12].v.ob[1] = pauseCtx->infoPanelVtx[13].v.ob[1] = D_8082B920;
+
+        pauseCtx->infoPanelVtx[14].v.ob[1] = pauseCtx->infoPanelVtx[15].v.ob[1] =
+            pauseCtx->infoPanelVtx[12].v.ob[1] - 32;
+    } else {
+        pauseCtx->infoPanelVtx[12].v.ob[0] = pauseCtx->infoPanelVtx[14].v.ob[0] = sPauseCursorRightX + 3;
+
+        pauseCtx->infoPanelVtx[13].v.ob[0] = pauseCtx->infoPanelVtx[15].v.ob[0] =
+            pauseCtx->infoPanelVtx[12].v.ob[0] + 18;
+
+        pauseCtx->infoPanelVtx[12].v.ob[1] = pauseCtx->infoPanelVtx[13].v.ob[1] = D_8082B920 - 3;
+
+        pauseCtx->infoPanelVtx[14].v.ob[1] = pauseCtx->infoPanelVtx[15].v.ob[1] =
+            pauseCtx->infoPanelVtx[12].v.ob[1] - 26;
+    }
+
+    pauseCtx->infoPanelVtx[9].v.tc[0] = pauseCtx->infoPanelVtx[11].v.tc[0] = pauseCtx->infoPanelVtx[13].v.tc[0] =
+        pauseCtx->infoPanelVtx[15].v.tc[0] = 24 * (1 << 5);
+
+    pauseCtx->infoPanelVtx[10].v.tc[1] = pauseCtx->infoPanelVtx[11].v.tc[1] = pauseCtx->infoPanelVtx[14].v.tc[1] =
+        pauseCtx->infoPanelVtx[15].v.tc[1] = 32 * (1 << 5);
+
+    gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
+
+    Matrix_Translate(0.0f, 0.0f, -144.0f, MTXMODE_NEW);
+    Matrix_Scale(1.0f, 1.0f, 1.0f, MTXMODE_APPLY);
+
+    gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+    // gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 150, 140, 90, 255);
+    gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, pauseExtraColor.r, pauseExtraColor.g, pauseExtraColor.b, 255);
+    gSPVertex(POLY_OPA_DISP++, &pauseCtx->infoPanelVtx[0], 16, 0);
+
+    gSPDisplayList(POLY_OPA_DISP++, gItemNamePanelDL);
+
+    if ((pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) &&
+        (!pauseCtx->mainState || (pauseCtx->mainState == PAUSE_MAIN_STATE_UNK))) {
+        // gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 150, 140, 90, sPauseZRCursorAlpha);
+        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, pauseExtraColor.r, pauseExtraColor.g, pauseExtraColor.b, sPauseZRCursorAlpha);
+    }
+
+    gSPDisplayList(POLY_OPA_DISP++, gZButtonIconDL);
+
+    if ((pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_RIGHT) &&
+        (!pauseCtx->mainState || (pauseCtx->mainState == PAUSE_MAIN_STATE_UNK))) {
+        // gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 150, 140, 90, sPauseZRCursorAlpha);
+        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, pauseExtraColor.r, pauseExtraColor.g, pauseExtraColor.b, sPauseZRCursorAlpha);
+    }
+
+    gSPDisplayList(POLY_OPA_DISP++, gRButtonIconDL);
+
+    if (pauseCtx->cursorSpecialPos != 0) {
+        j = (pauseCtx->cursorSpecialPos * 4) - 32;
+        pauseCtx->cursorVtx[0].v.ob[0] = pauseCtx->infoPanelVtx[j].v.ob[0];
+        pauseCtx->cursorVtx[0].v.ob[1] = pauseCtx->infoPanelVtx[j].v.ob[1];
+    }
+
+    y = pauseCtx->infoPanelOffsetY - 80;
+    pauseCtx->infoPanelVtx[16].v.ob[1] = pauseCtx->infoPanelVtx[17].v.ob[1] = y;
+
+    pauseCtx->infoPanelVtx[18].v.ob[1] = pauseCtx->infoPanelVtx[19].v.ob[1] = pauseCtx->infoPanelVtx[16].v.ob[1] - 16;
+
+    pauseCtx->infoPanelVtx[18].v.tc[1] = pauseCtx->infoPanelVtx[19].v.tc[1] = 16 * (1 << 5);
+
+    gDPPipeSync(POLY_OPA_DISP++);
+    gDPSetCombineLERP(POLY_OPA_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0, PRIMITIVE,
+                      ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+    gDPSetEnvColor(POLY_OPA_DISP++, 20, 30, 40, 0);
+
+    if (pauseCtx->itemDescriptionOn ||
+        ((pauseCtx->state == PAUSE_STATE_MAIN) && (pauseCtx->namedItem != PAUSE_ITEM_NONE) &&
+         (pauseCtx->nameDisplayTimer < 40) &&
+         (!pauseCtx->mainState || (pauseCtx->mainState == PAUSE_MAIN_STATE_SONG_PLAYBACK) ||
+          (pauseCtx->mainState == PAUSE_MAIN_STATE_UNK) ||
+          ((pauseCtx->mainState >= PAUSE_MAIN_STATE_SONG_PROMPT_INIT) &&
+           (pauseCtx->mainState <= PAUSE_MAIN_STATE_SONG_PROMPT_UNUSED)) ||
+          (pauseCtx->mainState == PAUSE_MAIN_STATE_IDLE_CURSOR_ON_SONG)) &&
+         (pauseCtx->cursorSpecialPos == 0))) {
+        if (!pauseCtx->mainState || (pauseCtx->mainState == PAUSE_MAIN_STATE_SONG_PLAYBACK) ||
+            (pauseCtx->mainState == PAUSE_MAIN_STATE_UNK) ||
+            ((pauseCtx->mainState >= PAUSE_MAIN_STATE_SONG_PROMPT_INIT) &&
+             (pauseCtx->mainState <= PAUSE_MAIN_STATE_SONG_PROMPT_UNUSED)) ||
+            (pauseCtx->mainState == PAUSE_MAIN_STATE_IDLE_CURSOR_ON_SONG)) {
+
+            pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] = -63;
+
+            pauseCtx->infoPanelVtx[17].v.ob[0] = pauseCtx->infoPanelVtx[19].v.ob[0] =
+                pauseCtx->infoPanelVtx[16].v.ob[0] + 128;
+
+            pauseCtx->infoPanelVtx[17].v.tc[0] = pauseCtx->infoPanelVtx[19].v.tc[0] = 128 * (1 << 5);
+
+            gSPVertex(POLY_OPA_DISP++, &pauseCtx->infoPanelVtx[16], 4, 0);
+
+            if (pauseCtx->nameColorSet == PAUSE_NAME_COLOR_SET_GREY) {
+                gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 70, 70, 70, 255);
+            } else {
+                gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, 255);
+            }
+
+            POLY_OPA_DISP = Gfx_DrawTexQuad4b(POLY_OPA_DISP, pauseCtx->nameSegment, G_IM_FMT_IA, 128, 16, 0);
+        }
+    } else if ((pauseCtx->mainState <= PAUSE_MAIN_STATE_SONG_PLAYBACK) ||
+               (pauseCtx->mainState == PAUSE_MAIN_STATE_SONG_PROMPT_UNUSED) ||
+               (pauseCtx->mainState == PAUSE_MAIN_STATE_IDLE_CURSOR_ON_SONG) ||
+               (pauseCtx->mainState == PAUSE_MAIN_STATE_UNK)) {
+        pauseCtx->infoPanelVtx[20].v.ob[1] = pauseCtx->infoPanelVtx[21].v.ob[1] = y;
+
+        pauseCtx->infoPanelVtx[22].v.ob[1] = pauseCtx->infoPanelVtx[23].v.ob[1] =
+            pauseCtx->infoPanelVtx[20].v.ob[1] - 16;
+
+        pauseCtx->infoPanelVtx[22].v.tc[1] = pauseCtx->infoPanelVtx[23].v.tc[1] = 16 * (1 << 5);
+
+        gSPVertex(POLY_OPA_DISP++, &pauseCtx->infoPanelVtx[16], 8, 0);
+
+        if (pauseCtx->state == PAUSE_STATE_SAVEPROMPT) {
+            pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] = -33;
+
+            pauseCtx->infoPanelVtx[17].v.ob[0] = pauseCtx->infoPanelVtx[19].v.ob[0] =
+                pauseCtx->infoPanelVtx[16].v.ob[0] + 24;
+
+            pauseCtx->infoPanelVtx[20].v.ob[0] = pauseCtx->infoPanelVtx[22].v.ob[0] =
+                pauseCtx->infoPanelVtx[16].v.ob[0] + 0x10;
+
+            pauseCtx->infoPanelVtx[21].v.ob[0] = pauseCtx->infoPanelVtx[23].v.ob[0] =
+                pauseCtx->infoPanelVtx[20].v.ob[0] + 0x30;
+
+            pauseCtx->infoPanelVtx[17].v.tc[0] = pauseCtx->infoPanelVtx[19].v.tc[0] = 24 * (1 << 5);
+
+            pauseCtx->infoPanelVtx[21].v.tc[0] = pauseCtx->infoPanelVtx[23].v.tc[0] = 48 * (1 << 5);
+
+            gSPDisplayList(POLY_OPA_DISP++, gAButtonIconDL);
+            gDPPipeSync(POLY_OPA_DISP++);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, 255);
+
+            //! @bug: Incorrect dimensions. Should be 64x16
+            POLY_OPA_DISP = Gfx_DrawTexQuad4b(POLY_OPA_DISP, gPauseToDecideENGTex, G_IM_FMT_IA, 48, 16, 4);
+
+        } else if (pauseCtx->cursorSpecialPos != 0) {
+            if ((pauseCtx->state == PAUSE_STATE_MAIN) && (pauseCtx->mainState == PAUSE_MAIN_STATE_IDLE)) {
+
+                pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] = -63;
+
+                pauseCtx->infoPanelVtx[17].v.ob[0] = pauseCtx->infoPanelVtx[19].v.ob[0] =
+                    pauseCtx->infoPanelVtx[16].v.ob[0] + 128;
+
+                pauseCtx->infoPanelVtx[17].v.tc[0] = pauseCtx->infoPanelVtx[19].v.tc[0] = 128 * (1 << 5);
+
+                gDPPipeSync(POLY_OPA_DISP++);
+				// TODO: add misc colors like this
+				gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 200, 0, 255);
+                // gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 100, 255, 255);
+
+                if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
+                    POLY_OPA_DISP =
+                        Gfx_DrawTexQuad4b(POLY_OPA_DISP, D_8082B998[pauseCtx->pageIndex], G_IM_FMT_IA, 128, 16, 0);
+                } else {
+                    POLY_OPA_DISP =
+                        Gfx_DrawTexQuad4b(POLY_OPA_DISP, D_8082B9A8[pauseCtx->pageIndex], G_IM_FMT_IA, 128, 16, 0);
+                }
+            }
+        } else if ((!pauseCtx->pageIndex || (pauseCtx->pageIndex == PAUSE_MASK)) &&
+                   (pauseCtx->namedItem != PAUSE_ITEM_NONE)) {
+            pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] = -49;
+
+            pauseCtx->infoPanelVtx[17].v.ob[0] = pauseCtx->infoPanelVtx[19].v.ob[0] =
+                pauseCtx->infoPanelVtx[16].v.ob[0] + 48;
+
+            pauseCtx->infoPanelVtx[20].v.ob[0] = pauseCtx->infoPanelVtx[22].v.ob[0] =
+                pauseCtx->infoPanelVtx[16].v.ob[0] + 47;
+
+            pauseCtx->infoPanelVtx[21].v.ob[0] = pauseCtx->infoPanelVtx[23].v.ob[0] =
+                pauseCtx->infoPanelVtx[20].v.ob[0] + 64;
+
+            pauseCtx->infoPanelVtx[17].v.tc[0] = pauseCtx->infoPanelVtx[19].v.tc[0] = 48 * (1 << 5);
+
+            pauseCtx->infoPanelVtx[21].v.tc[0] = pauseCtx->infoPanelVtx[23].v.tc[0] = 64 * (1 << 5);
+
+            gSPDisplayList(POLY_OPA_DISP++, gCButtonIconsDL);
+
+            gDPPipeSync(POLY_OPA_DISP++);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, 255);
+
+            POLY_OPA_DISP = Gfx_DrawTexQuad4b(POLY_OPA_DISP, gPauseToEquipENGTex, G_IM_FMT_IA, 64, 16, 4);
+        } else if ((pauseCtx->pageIndex == PAUSE_MAP) && sInDungeonScene) {
+            // No code in this case
+        } else if ((pauseCtx->pageIndex == PAUSE_QUEST) &&
+                   (pauseCtx->cursorSlot[PAUSE_QUEST] == QUEST_BOMBERS_NOTEBOOK)) {
+            if (pauseCtx->namedItem != PAUSE_ITEM_NONE) {
+                // The cursor is on the bombers notebook
+                pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] = -58;
+
+                pauseCtx->infoPanelVtx[17].v.ob[0] = pauseCtx->infoPanelVtx[19].v.ob[0] =
+                    pauseCtx->infoPanelVtx[16].v.ob[0] + 24;
+
+                pauseCtx->infoPanelVtx[20].v.ob[0] = pauseCtx->infoPanelVtx[22].v.ob[0] =
+                    pauseCtx->infoPanelVtx[16].v.ob[0] + 0x14;
+
+                pauseCtx->infoPanelVtx[21].v.ob[0] = pauseCtx->infoPanelVtx[23].v.ob[0] =
+                    pauseCtx->infoPanelVtx[20].v.ob[0] + 0x60;
+
+                pauseCtx->infoPanelVtx[17].v.tc[0] = pauseCtx->infoPanelVtx[19].v.tc[0] = 24 * (1 << 5);
+
+                pauseCtx->infoPanelVtx[21].v.tc[0] = pauseCtx->infoPanelVtx[23].v.tc[0] = 96 * (1 << 5);
+
+                gSPDisplayList(POLY_OPA_DISP++, gAButtonIconDL);
+
+                gDPPipeSync(POLY_OPA_DISP++);
+                gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, 255);
+
+                POLY_OPA_DISP = Gfx_DrawTexQuad4b(POLY_OPA_DISP, gPauseToViewNotebookENGTex, G_IM_FMT_IA, 96, 16, 4);
+            }
+        } else if ((pauseCtx->pageIndex == PAUSE_QUEST) && (pauseCtx->cursorSlot[PAUSE_QUEST] >= QUEST_SONG_SONATA) &&
+                   (pauseCtx->cursorSlot[PAUSE_QUEST] <= QUEST_SONG_SUN) && (pauseCtx->namedItem != PAUSE_ITEM_NONE)) {
+            // The cursor is on a learned song
+            pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] = -55;
+
+            pauseCtx->infoPanelVtx[17].v.ob[0] = pauseCtx->infoPanelVtx[19].v.ob[0] =
+                pauseCtx->infoPanelVtx[16].v.ob[0] + 24;
+
+            pauseCtx->infoPanelVtx[20].v.ob[0] = pauseCtx->infoPanelVtx[22].v.ob[0] =
+                pauseCtx->infoPanelVtx[16].v.ob[0] + 20;
+
+            pauseCtx->infoPanelVtx[21].v.ob[0] = pauseCtx->infoPanelVtx[23].v.ob[0] =
+                pauseCtx->infoPanelVtx[20].v.ob[0] + 96;
+
+            pauseCtx->infoPanelVtx[17].v.tc[0] = pauseCtx->infoPanelVtx[19].v.tc[0] = 24 * (1 << 5);
+
+            pauseCtx->infoPanelVtx[21].v.tc[0] = pauseCtx->infoPanelVtx[23].v.tc[0] = 96 * (1 << 5);
+
+            gSPDisplayList(POLY_OPA_DISP++, gAButtonIconDL);
+
+            gDPPipeSync(POLY_OPA_DISP++);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, 255);
+
+            POLY_OPA_DISP = Gfx_DrawTexQuad4b(POLY_OPA_DISP, gPauseToPlayMelodyENGTex, G_IM_FMT_IA, 96, 16, 4);
+        }
+    }
+
+    CLOSE_DISPS(play->state.gfxCtx);
+}

--- a/src/tatl_color.c
+++ b/src/tatl_color.c
@@ -1,0 +1,201 @@
+#include "modding.h"
+#include "global.h"
+
+// sets both inner and outer to be the same for now
+Color_RGB8 tatlSolidColor = {255, 255, 230};
+
+typedef struct {
+    /* 0x0 */ Color_RGBA8 inner;
+    /* 0x4 */ Color_RGBA8 outer;
+} TatlColor; // size = 0x8
+
+// unsure if these will be used
+TatlColor sTatlColorList[] = {
+    { { 0, 255, 0, 255 }, { 0, 255, 0, 0 } },         // ACTORCAT_SWITCH
+    { { 0, 255, 0, 255 }, { 0, 255, 0, 0 } },         // ACTORCAT_BG
+    { { 255, 255, 230, 255 }, { 220, 160, 80, 0 } },  // ACTORCAT_PLAYER
+    { { 0, 255, 0, 255 }, { 0, 255, 0, 0 } },         // ACTORCAT_EXPLOSIVES
+    { { 150, 150, 255, 255 }, { 150, 150, 255, 0 } }, // ACTORCAT_NPC
+    { { 255, 255, 0, 255 }, { 200, 155, 0, 0 } },     // ACTORCAT_ENEMY
+    { { 0, 255, 0, 255 }, { 0, 255, 0, 0 } },         // ACTORCAT_PROP
+    { { 0, 255, 0, 255 }, { 0, 255, 0, 0 } },         // ACTORCAT_ITEMACTION
+    { { 0, 255, 0, 255 }, { 0, 255, 0, 0 } },         // ACTORCAT_MISC
+    { { 255, 255, 0, 255 }, { 200, 155, 0, 0 } },     // ACTORCAT_BOSS
+    { { 0, 255, 0, 255 }, { 0, 255, 0, 0 } },         // ACTORCAT_DOOR
+    { { 0, 255, 0, 255 }, { 0, 255, 0, 0 } },         // ACTORCAT_CHEST
+    { { 0, 255, 0, 255 }, { 0, 255, 0, 0 } },         // ACTORCAT_MAX
+};
+
+RECOMP_PATCH void Target_SetFairyState(TargetContext* targetCtx, Actor* actor, ActorType type, PlayState* play) {
+    targetCtx->fairyPos.x = actor->focus.pos.x;
+    targetCtx->fairyPos.y = actor->focus.pos.y + (actor->targetArrowOffset * actor->scale.y);
+    targetCtx->fairyPos.z = actor->focus.pos.z;
+
+    // targetCtx->fairyInnerColor.r = sTatlColorList[type].inner.r;
+    // targetCtx->fairyInnerColor.g = sTatlColorList[type].inner.g;
+    // targetCtx->fairyInnerColor.b = sTatlColorList[type].inner.b;
+    // targetCtx->fairyInnerColor.a = sTatlColorList[type].inner.a;
+    // targetCtx->fairyOuterColor.r = sTatlColorList[type].outer.r;
+    // targetCtx->fairyOuterColor.g = sTatlColorList[type].outer.g;
+    // targetCtx->fairyOuterColor.b = sTatlColorList[type].outer.b;
+    // targetCtx->fairyOuterColor.a = sTatlColorList[type].outer.a;
+    targetCtx->fairyInnerColor.r = tatlSolidColor.r;
+    targetCtx->fairyInnerColor.g = tatlSolidColor.g;
+    targetCtx->fairyInnerColor.b = tatlSolidColor.b;
+    targetCtx->fairyInnerColor.a = sTatlColorList[type].inner.a;
+    targetCtx->fairyOuterColor.r = tatlSolidColor.r;
+    targetCtx->fairyOuterColor.g = tatlSolidColor.g;
+    targetCtx->fairyOuterColor.b = tatlSolidColor.b;
+    targetCtx->fairyOuterColor.a = sTatlColorList[type].outer.a;
+}
+
+void Target_SetLockOnPos(TargetContext* targetCtx, s32 index, f32 x, f32 y, f32 z);
+
+RECOMP_PATCH void Target_InitLockOn(TargetContext* targetCtx, ActorType type, PlayState* play) {
+    TatlColor* tatlColorEntry;
+    s32 i;
+    LockOnTriangleSet* triangleSet;
+
+    Math_Vec3f_Copy(&targetCtx->lockOnPos, &play->view.eye);
+    targetCtx->lockOnAlpha = 256;
+    // tatlColorEntry = &sTatlColorList[type];
+    targetCtx->lockOnRadius = 500.0f;
+
+    triangleSet = targetCtx->lockOnTriangleSets;
+    for (i = 0; i < ARRAY_COUNT(targetCtx->lockOnTriangleSets); i++, triangleSet++) {
+        Target_SetLockOnPos(targetCtx, i, 0.0f, 0.0f, 0.0f);
+
+        // triangleSet->color.r = tatlColorEntry->inner.r;
+        // triangleSet->color.g = tatlColorEntry->inner.g;
+        // triangleSet->color.b = tatlColorEntry->inner.b;
+        triangleSet->color.r = tatlSolidColor.r;
+        triangleSet->color.g = tatlSolidColor.g;
+        triangleSet->color.b = tatlSolidColor.b;
+    }
+}
+
+extern Gfx gZTargetLockOnTriangleDL[];
+extern Gfx gZTargetArrowDL[];
+
+RECOMP_PATCH void Target_Draw(TargetContext* targetCtx, PlayState* play) {
+    Player* player = GET_PLAYER(play);
+    Actor* actor;
+
+    if (player->stateFlags1 & (PLAYER_STATE1_2 | PLAYER_STATE1_40 | PLAYER_STATE1_80 | PLAYER_STATE1_200 |
+                               PLAYER_STATE1_400 | PLAYER_STATE1_10000000 | PLAYER_STATE1_20000000)) {
+        return;
+    }
+
+    actor = targetCtx->lockOnActor;
+
+    OPEN_DISPS(play->state.gfxCtx);
+
+    if (targetCtx->lockOnAlpha != 0) {
+        LockOnTriangleSet* entry;
+        s16 alpha = 255;
+        f32 projectdPosScale = 1.0f;
+        Vec3f projectedPos;
+        s32 totalEntries;
+        f32 invW;
+        s32 i;
+        s32 index;
+        f32 lockOnScaleX;
+
+        if (targetCtx->rotZTick != 0) {
+            totalEntries = 1;
+        } else {
+            // Use multiple entries for the movement effect when the triangles are getting closer to the actor from the
+            // margin of the screen
+            totalEntries = ARRAY_COUNT(targetCtx->lockOnTriangleSets);
+        }
+
+        if (actor != NULL) {
+            Math_Vec3f_Copy(&targetCtx->lockOnPos, &actor->focus.pos);
+            projectdPosScale = (500.0f - targetCtx->lockOnRadius) / 420.0f;
+        } else {
+            targetCtx->lockOnAlpha -= 120;
+            if (targetCtx->lockOnAlpha < 0) {
+                targetCtx->lockOnAlpha = 0;
+            }
+            alpha = targetCtx->lockOnAlpha;
+        }
+
+        Actor_GetProjectedPos(play, &targetCtx->lockOnPos, &projectedPos, &invW);
+
+        projectedPos.x = ((SCREEN_WIDTH / 2) * (projectedPos.x * invW)) * projectdPosScale;
+        projectedPos.x = CLAMP(projectedPos.x, -SCREEN_WIDTH, SCREEN_WIDTH);
+
+        projectedPos.y = ((SCREEN_HEIGHT / 2) * (projectedPos.y * invW)) * projectdPosScale;
+        projectedPos.y = CLAMP(projectedPos.y, -SCREEN_HEIGHT, SCREEN_HEIGHT);
+
+        projectedPos.z *= projectdPosScale;
+
+        targetCtx->lockOnIndex--;
+        if (targetCtx->lockOnIndex < 0) {
+            targetCtx->lockOnIndex = ARRAY_COUNT(targetCtx->lockOnTriangleSets) - 1;
+        }
+
+        Target_SetLockOnPos(targetCtx, targetCtx->lockOnIndex, projectedPos.x, projectedPos.y, projectedPos.z);
+
+        if (!(player->stateFlags1 & PLAYER_STATE1_40) || (actor != player->lockOnActor)) {
+            OVERLAY_DISP = Gfx_SetupDL(OVERLAY_DISP, SETUPDL_57);
+
+            for (i = 0, index = targetCtx->lockOnIndex; i < totalEntries;
+                 i++, index = (index + 1) % ARRAY_COUNT(targetCtx->lockOnTriangleSets)) {
+                entry = &targetCtx->lockOnTriangleSets[index];
+
+                if (entry->radius < 500.0f) {
+                    s32 triangleIndex;
+
+                    if (entry->radius <= 120.0f) {
+                        lockOnScaleX = 0.15f;
+                    } else {
+                        lockOnScaleX = ((entry->radius - 120.0f) * 0.001f) + 0.15f;
+                    }
+
+                    Matrix_Translate(entry->pos.x, entry->pos.y, 0.0f, MTXMODE_NEW);
+                    Matrix_Scale(lockOnScaleX, 0.15f, 1.0f, MTXMODE_APPLY);
+
+                    // gDPSetPrimColor(OVERLAY_DISP++, 0, 0, entry->color.r, entry->color.g, entry->color.b, (u8)alpha);
+                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, tatlSolidColor.r, tatlSolidColor.g, tatlSolidColor.b, (u8)alpha);
+
+                    Matrix_RotateZS(targetCtx->rotZTick * 0x200, MTXMODE_APPLY);
+
+                    // Draw the 4 lock-on triangles
+                    for (triangleIndex = 0; triangleIndex < 4; triangleIndex++) {
+                        Matrix_RotateZS(0x10000 / 4, MTXMODE_APPLY);
+                        Matrix_Push();
+                        Matrix_Translate(entry->radius, entry->radius, 0.0f, MTXMODE_APPLY);
+                        gSPMatrix(OVERLAY_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_MODELVIEW | G_MTX_LOAD);
+                        gSPDisplayList(OVERLAY_DISP++, gZTargetLockOnTriangleDL);
+                        Matrix_Pop();
+                    }
+                }
+
+                alpha -= 255 / ARRAY_COUNT(targetCtx->lockOnTriangleSets);
+                if (alpha < 0) {
+                    alpha = 0;
+                }
+            }
+        }
+    }
+
+    actor = targetCtx->arrowPointedActor;
+    if ((actor != NULL) && !(actor->flags & ACTOR_FLAG_CANT_LOCK_ON)) {
+        TatlColor* color = &sTatlColorList[actor->category];
+
+        POLY_XLU_DISP = Gfx_SetupDL(POLY_XLU_DISP, SETUPDL_7);
+
+        Matrix_Translate(actor->focus.pos.x, actor->focus.pos.y + (actor->targetArrowOffset * actor->scale.y) + 17.0f,
+                         actor->focus.pos.z, MTXMODE_NEW);
+        Matrix_RotateYS(play->gameplayFrames * 0xBB8, MTXMODE_APPLY);
+        Matrix_Scale((iREG(27) + 35) / 1000.0f, (iREG(28) + 60) / 1000.0f, (iREG(29) + 50) / 1000.0f, MTXMODE_APPLY);
+
+        // gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, color->inner.r, color->inner.g, color->inner.b, 255);
+        gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, tatlSolidColor.r, tatlSolidColor.g, tatlSolidColor.b, 255);
+        gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_MODELVIEW | G_MTX_LOAD);
+        gSPDisplayList(POLY_XLU_DISP++, gZTargetArrowDL);
+    }
+
+    CLOSE_DISPS(play->state.gfxCtx);
+}


### PR DESCRIPTION
This is just a basic implementation of all the things I think should have options to be colored so far. I also currently have colors working for Tatl and the File Select screen, but I'm not sure if I should add them here.

I think that any logic/presets for the colors should be handled via the apworld rather than the mod since they are being sent anyways, and they should also default to vanilla colors if nothing is provided.