### PR TITLE
add a few cutscene skips

### DIFF
--- a/src/deku_princess_hooks.c
+++ b/src/deku_princess_hooks.c
@@ -1,0 +1,78 @@
+#include "modding.h"
+#include "global.h"
+
+#include "apcommon.h"
+
+struct EnDnp;
+
+typedef void (*EnDnpActionFunc)(struct EnDnp*, PlayState*);
+
+#define DEKU_PRINCESS_LIMB_MAX 0x1A
+
+typedef struct EnDnp {
+    /* 0x000 */ Actor actor;
+    /* 0x144 */ SkelAnime skelAnime;
+    /* 0x188 */ EnDnpActionFunc actionFunc;
+    /* 0x18C */ ColliderCylinder collider;
+    /* 0x1D8 */ Vec3f unk_1D8;
+    /* 0x1E4 */ Vec3s unk_1E4;
+    /* 0x1EA */ Vec3s jointTable[DEKU_PRINCESS_LIMB_MAX];
+    /* 0x286 */ Vec3s morphTable[DEKU_PRINCESS_LIMB_MAX];
+    /* 0x322 */ u16 unk_322;
+    /* 0x324 */ u8 cueId;
+    /* 0x328 */ s32 unk_328;
+    /* 0x32C */ UNK_TYPE1 unk_32C[0x2];
+    /* 0x32E */ s16 unk_32E;
+    /* 0x330 */ s16 unk_330;
+    /* 0x332 */ s16 unk_332;
+    /* 0x334 */ s16 blinkTimer;
+    /* 0x336 */ s16 eyeIndex;
+    /* 0x338 */ s16 unk_338;
+    /* 0x33A */ UNK_TYPE1 unk_33A[0x6];
+    /* 0x340 */ s32 animIndex;
+} EnDnp; // size = 0x344
+
+RECOMP_PATCH void func_80B3D558(EnDnp* this, PlayState* play) {
+    if (CutsceneManager_IsNext(this->actor.csId)) {
+        SET_WEEKEVENTREG(WEEKEVENTREG_23_20);
+        play->nextEntrance = ENTRANCE(DEKU_KINGS_CHAMBER, 3);
+        play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
+        gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
+        play->transitionTrigger = TRANS_TRIGGER_START;
+        // CutsceneManager_StartWithPlayerCs(this->actor.csId, &this->actor);
+    } else {
+        CutsceneManager_Queue(this->actor.csId);
+    }
+}
+
+struct BgDkjailIvy;
+
+typedef void (*BgDkjailIvyActionFunc)(struct BgDkjailIvy*, PlayState*);
+
+typedef struct BgDkjailIvy {
+    /* 0x000 */ DynaPolyActor dyna;
+    /* 0x15C */ ColliderCylinder collider;
+    /* 0x1A8 */ BgDkjailIvyActionFunc actionFunc;
+    /* 0x1AC */ s8 fadeOutTimer;
+    /* 0x1AD */ u8 alpha;
+} BgDkjailIvy; // size = 0x1B0
+
+#define BG_DKJAIL_GET_SWITCH_FLAG(thisx) ((thisx)->params & 0x7F)
+
+void BgDkjailIvy_IvyCutEffects(BgDkjailIvy* this, PlayState* play);
+void BgDkjailIvy_SetupFadeOut(BgDkjailIvy* this);
+
+RECOMP_PATCH void BgDkjailIvy_BeginCutscene(BgDkjailIvy* this, PlayState* play) {
+    if (CutsceneManager_IsNext(this->dyna.actor.csId)) {
+        // CutsceneManager_StartWithPlayerCs(this->dyna.actor.csId, &this->dyna.actor);
+        func_800B7298(play, NULL, PLAYER_CSACTION_END);
+        this->fadeOutTimer = 50;
+        DynaPoly_DisableCollision(play, &play->colCtx.dyna, this->dyna.bgId);
+        Flags_SetSwitch(play, BG_DKJAIL_GET_SWITCH_FLAG(&this->dyna.actor));
+        BgDkjailIvy_IvyCutEffects(this, play);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_GRASS_WALL_BROKEN);
+        BgDkjailIvy_SetupFadeOut(this);
+    } else {
+        CutsceneManager_Queue(this->dyna.actor.csId);
+    }
+}

--- a/src/evan_hooks.c
+++ b/src/evan_hooks.c
@@ -1,0 +1,101 @@
+#include "modding.h"
+#include "global.h"
+
+#include "apcommon.h"
+
+struct EnZos;
+
+typedef void (*EnZosActionFunc)(struct EnZos*, PlayState*);
+
+#define EVAN_LIMB_MAX 0x12
+
+typedef struct EnZos {
+    /* 0x000 */ Actor actor;
+    /* 0x144 */ Vec3s jointTable[EVAN_LIMB_MAX];
+    /* 0x1B0 */ Vec3s morphTable[EVAN_LIMB_MAX];
+    /* 0x21C */ SkelAnime skelAnime;
+    /* 0x260 */ ColliderCylinder collider;
+    /* 0x2AC */ s16 eyeIndex;
+    /* 0x2AE */ s16 blinkTimer;
+    /* 0x2B0 */ UNK_TYPE1 unk2B0[6];
+    /* 0x2B6 */ u16 unk_2B6;
+    /* 0x2B8 */ s16 animIndex;
+    /* 0x2BA */ s16 cueId;
+    /* 0x2BC */ s16 unk_2BC;
+    /* 0x2C0 */ EnZosActionFunc actionFunc;
+} EnZos; // size = 0x2C4
+
+#define EN_ZOS_ANIM_LEAN_ON_KEYBOARD 0x00
+
+void EnZos_ChangeAnim(EnZos* this, s16 animIndex, u8 animMode);
+void func_80BBBB84(EnZos* this, PlayState* play);
+void func_80BBB8AC(EnZos* this, PlayState* play);
+void func_80BBBD5C(EnZos* this, PlayState* play);
+void func_80BBB0D4(EnZos* this, PlayState* play);
+void func_80BBB15C(EnZos* this, PlayState* play);
+s32 func_80BBAF5C(EnZos* this, PlayState* play);
+void func_80BBB2C4(EnZos* this, PlayState* play);
+
+void func_80BBB354(EnZos* this, PlayState* play) {
+    // s32 getItemId;
+
+    if (Actor_HasParent(&this->actor, play)) {
+        this->actor.parent = NULL;
+        this->actionFunc = func_80BBB2C4;
+        SET_WEEKEVENTREG(WEEKEVENTREG_39_20);
+        this->actor.flags |= ACTOR_FLAG_10000;
+        Actor_OfferTalkExchange(&this->actor, play, 1000.0f, 1000.0f, PLAYER_IA_MINUS1);
+    } else {
+        // if (CHECK_WEEKEVENTREG(WEEKEVENTREG_39_20)) {
+        //     getItemId = GI_RUPEE_PURPLE;
+        // } else {
+        //     getItemId = GI_HEART_PIECE;
+        // }
+        Actor_OfferGetItem(&this->actor, play, GI_HEART_PIECE, 10000.0f, 50.0f);
+    }
+}
+
+RECOMP_PATCH void func_80BBBDE0(EnZos* this, PlayState* play) {
+    Actor* thisx = &this->actor;
+    Vec3f seqPos;
+
+    if (this->unk_2B6 & 1) {
+        Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.home.rot.y, 2, 0x1000, 0x200);
+        this->actor.world.rot.y = thisx->shape.rot.y;
+        if (this->actor.home.rot.y == thisx->shape.rot.y) {
+            EnZos_ChangeAnim(this, EN_ZOS_ANIM_LEAN_ON_KEYBOARD, ANIMMODE_ONCE);
+            this->unk_2B6 &= ~1;
+        }
+    }
+
+    func_80BBB0D4(this, play);
+
+    if (play->msgCtx.ocarinaMode == OCARINA_MODE_PLAYED_FULL_EVAN_SONG) {
+        play->msgCtx.ocarinaMode = OCARINA_MODE_END;
+        this->actionFunc = func_80BBB354;
+        // this->actionFunc = func_80BBBB84;
+        // this->actor.flags |= ACTOR_FLAG_10000;
+        // Actor_OfferTalk(&this->actor, play, 120.0f);
+        return;
+    }
+
+    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        this->actionFunc = func_80BBB8AC;
+        func_80BBB15C(this, play);
+    } else if (Cutscene_IsCueInChannel(play, CS_CMD_ACTOR_CUE_501)) {
+        this->actionFunc = func_80BBBD5C;
+    } else if (func_80BBAF5C(this, play)) {
+        Actor_OfferTalk(&this->actor, play, 120.0f);
+    }
+
+    if (!Actor_IsFacingPlayer(&this->actor, 0x4000) && (this->actor.xzDistToPlayer < 100.0f)) {
+        SET_WEEKEVENTREG(WEEKEVENTREG_52_10);
+    } else {
+        CLEAR_WEEKEVENTREG(WEEKEVENTREG_52_10);
+    }
+
+    seqPos.x = this->actor.projectedPos.x;
+    seqPos.y = this->actor.projectedPos.y;
+    seqPos.z = this->actor.projectedPos.z;
+    Audio_PlaySequenceAtPos(SEQ_PLAYER_BGM_SUB, &seqPos, NA_BGM_PIANO_PLAY, 1000.0f);
+}

--- a/src/ice_poly_hooks.c
+++ b/src/ice_poly_hooks.c
@@ -1,0 +1,39 @@
+#include "modding.h"
+#include "global.h"
+
+#include "apcommon.h"
+
+struct ObjIcePoly;
+
+typedef void (*ObjIcePolyActionFunc)(struct ObjIcePoly*, PlayState*);
+
+typedef struct ObjIcePoly {
+    /* 0x000 */ Actor actor;
+    /* 0x144 */ ObjIcePolyActionFunc actionFunc;
+    /* 0x148 */ u8 unk_148;
+    /* 0x149 */ u8 switchFlag;
+    /* 0x14A */ s16 unk_14A;
+    /* 0x14C */ ColliderCylinder colliders1[2];
+    /* 0x1E4 */ ColliderCylinder colliders2[2];
+} ObjIcePoly; // size = 0x27C
+
+void func_80931828(ObjIcePoly* this, PlayState* play);
+void func_80931EEC(ObjIcePoly* this, PlayState* play);
+
+RECOMP_PATCH void func_80931E58(ObjIcePoly* this, PlayState* play) {
+    if (CutsceneManager_IsNext(this->actor.csId)) {
+        // CutsceneManager_StartWithPlayerCs(this->actor.csId, &this->actor);
+        func_800B7298(play, NULL, PLAYER_CSACTION_END);
+        if (this->unk_14A == 1) {
+            func_80931828(this, play);
+            Actor_Kill(&this->actor);
+            return;
+        }
+
+        this->unk_14A = 40;
+        Actor_PlaySfx(&this->actor, NA_SE_EV_ICE_MELT);
+        this->actionFunc = func_80931EEC;
+    } else {
+        CutsceneManager_Queue(this->actor.csId);
+    }
+}

--- a/src/init_save.c
+++ b/src/init_save.c
@@ -6,7 +6,6 @@
 #include "apcommon.h"
 
 bool saveOpened = false;
-bool spawnedTurtle = false;
 
 RECOMP_IMPORT(".", bool rando_get_permanent_chateau_romani_enabled());
 RECOMP_IMPORT(".", bool rando_get_start_with_consumables_enabled());
@@ -28,6 +27,7 @@ void Sram_GenerateRandomSaveFields(void);
 void Sram_ResetSave(void);
 
 bool drankChateau = false;
+bool spawnedTurtle = false;
 
 void Sram_SetInitialWeekEvents(void) {
     SET_WEEKEVENTREG(WEEKEVENTREG_15_20);
@@ -84,8 +84,9 @@ void Sram_SetInitialWeekEvents(void) {
     // moon's tear deku scrub starts out in flower
     SET_WEEKEVENTREG(PACK_WEEKEVENTREG_FLAG(73, 0x04));
 
-    // skip the princess prison cutscene
+    // skip the princess prison cutscenes
     SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_WOODFALL_TEMPLE_PRISON);
+    SET_WEEKEVENTREG(WEEKEVENTREG_29_40);
 
     // skip having to rewatch the great bay turtle cutscene
     if(spawnedTurtle) {
@@ -138,7 +139,6 @@ RECOMP_PATCH void Sram_InitDebugSave(void) {
 
     Sram_SetInitialWeekEvents();
 
-    // skip the *insanely long* skull kid tatl/tael backstory cutscene
     u8* save_ptr = (u8*) &gSaveContext;
     save_ptr[0x5EB] |= 0x10;
     save_ptr[0x42F3] |= 0x10;

--- a/src/init_save.c
+++ b/src/init_save.c
@@ -146,6 +146,9 @@ RECOMP_PATCH void Sram_InitDebugSave(void) {
     gSaveContext.cycleSceneFlags[SCENE_INSIDETOWER].switch0 = 1;
     gSaveContext.save.saveInfo.permanentSceneFlags[SCENE_INSIDETOWER].switch0 = 1;
 
+    gSaveContext.cycleSceneFlags[SCENE_PIRATE].switch1 |= (1 << 29);
+    gSaveContext.save.saveInfo.permanentSceneFlags[SCENE_PIRATE].switch1 |= (1 << 29);
+
     gSaveContext.save.saveInfo.playerData.healthCapacity = 0x10;
     gSaveContext.save.saveInfo.playerData.health = 0x10;
 
@@ -341,6 +344,9 @@ RECOMP_PATCH void Sram_SaveEndOfCycle(PlayState* play) {
 
     sceneId = Play_GetOriginalSceneId(play->sceneId);
     Play_SaveCycleSceneFlags(&play->state);
+
+    // sPersistentCycleSceneFlags override
+    sPersistentCycleSceneFlags[SCENE_PIRATE].switch1 |= (1 << 29);
 
     play->actorCtx.sceneFlags.chest &= sPersistentCycleSceneFlags[sceneId].chest;
     play->actorCtx.sceneFlags.switches[0] &= sPersistentCycleSceneFlags[sceneId].switch0;

--- a/src/init_save.c
+++ b/src/init_save.c
@@ -6,6 +6,7 @@
 #include "apcommon.h"
 
 bool saveOpened = false;
+bool spawnedTurtle = false;
 
 RECOMP_IMPORT(".", bool rando_get_permanent_chateau_romani_enabled());
 RECOMP_IMPORT(".", bool rando_get_start_with_consumables_enabled());
@@ -85,6 +86,11 @@ void Sram_SetInitialWeekEvents(void) {
 
     // skip the princess prison cutscene
     SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_WOODFALL_TEMPLE_PRISON);
+
+    // skip having to rewatch the great bay turtle cutscene
+    if(spawnedTurtle) {
+        SET_WEEKEVENTREG(WEEKEVENTREG_53_20);
+    }
 
     // restore chateau romani state after cycle reset
     if (drankChateau && rando_get_permanent_chateau_romani_enabled()) {
@@ -372,8 +378,9 @@ RECOMP_PATCH void Sram_SaveEndOfCycle(PlayState* play) {
         //Inventory_DeleteItem(ITEM_MASK_FIERCE_DEITY, SLOT(ITEM_MASK_FIERCE_DEITY));
     }
 
-    // persistent chateau romani state
+    // persistent flags
     drankChateau = CHECK_WEEKEVENTREG(WEEKEVENTREG_DRANK_CHATEAU_ROMANI);
+    spawnedTurtle = CHECK_WEEKEVENTREG(WEEKEVENTREG_53_20);
 
     for (i = 0; i < ARRAY_COUNT(sPersistentCycleWeekEventRegs); i++) {
         u16 isPersistentBits = sPersistentCycleWeekEventRegs[i];

--- a/src/scarecrow_hooks.c
+++ b/src/scarecrow_hooks.c
@@ -1,0 +1,63 @@
+#include "modding.h"
+#include "global.h"
+
+#include "apcommon.h"
+
+typedef s32 (*PictoValidationFunc)(struct PlayState*, Actor*);
+
+typedef struct {
+    /* 0x000 */ Actor actor;
+    /* 0x144 */ PictoValidationFunc validationFunc;
+} PictoActor;
+
+struct EnKakasi;
+
+typedef void (*EnKakasiActionFunc)(struct EnKakasi*, PlayState*);
+
+typedef struct EnKakasi {
+    /* 0x000 */ PictoActor picto;
+    /* 0x148 */ EnKakasiActionFunc actionFunc;
+    /* 0x14C */ SkelAnime skelAnime;
+    /* 0x190 */ s16 unk190; // camera index for song teaching angles?
+    /* 0x192 */ s16 postTeachTimer;
+    /* 0x194 */ s16 aboveGroundStatus; // from params, changed to 2 in init
+    /* 0x196 */ s16 unkState196;
+    /* 0x19A */ UNK_TYPE1 pad198[0x8];
+    /* 0x1A0 */ s32 animIndex;
+    /* 0x1A4 */ s32 unkCounter1A4; // counter, counts up to F while he digs away, reused elsewhere
+    /* 0x1A8 */ s32 unkState1A8;
+    /* 0x1AC */ s16 talkState;
+    /* 0x1AE */ s16 csIdList[3];
+    /* 0x1B4 */ f32 animEndFrame;
+    /* 0x1B8 */ f32 unkHeight;
+    /* 0x1BC */ Vec3f unk1BC; // set by post limbdraw func for one limb
+    /* 0x1C8 */ UNK_TYPE1 pad1C8[0x3C];
+    /* 0x204 */ s16 unk204; // set to A, F, 0x14, 0x28 frequently
+    /* 0x206 */ UNK_TYPE1 pad206[2];
+    /* 0x208 */ s16 subCamId;
+    /* 0x20C */ f32 subCamFov;
+    /* 0x210 */ f32 subCamFovNext;
+    /* 0x214 */ Vec3f subCamEye;
+    /* 0x220 */ Vec3f subCamAt;
+    /* 0x22C */ Vec3f unk22C;
+    /* 0x238 */ Vec3f subCamEyeNext;
+    /* 0x244 */ Vec3f subCamAtNext;
+    /* 0x250 */ f32 songSummonDist;
+    /* 0x254 */ ColliderCylinder collider;
+} EnKakasi; // size = 0x2A0
+
+#define ACTOR_FLAG_LOCK_ON_DISABLED  (1 << 27)
+
+void EnKakasi_SetupRiseOutOfGround(EnKakasi* this, PlayState* play);
+
+RECOMP_PATCH void EnKakasi_IdleUnderground(EnKakasi* this, PlayState* play) {
+    // if (CHECK_WEEKEVENTREG(WEEKEVENTREG_79_08) && (this->picto.actor.xzDistToPlayer < this->songSummonDist) &&
+    //     ((BREG(1) != 0) || (play->msgCtx.ocarinaMode == OCARINA_MODE_PLAYED_SCARECROW_SPAWN))) {
+    if ((this->picto.actor.xzDistToPlayer < this->songSummonDist) && ((BREG(1) != 0) || (play->msgCtx.ocarinaMode == OCARINA_MODE_ACTIVE))) {
+        this->picto.actor.flags &= ~ACTOR_FLAG_LOCK_ON_DISABLED;
+        play->msgCtx.ocarinaMode = OCARINA_MODE_END;
+        AudioOcarina_SetOcarinaDisableTimer(0, 20);
+        // Message_CloseTextbox(play);
+        this->actionFunc = EnKakasi_SetupRiseOutOfGround;
+    }
+}

--- a/src/shooting_gallery_hooks.c
+++ b/src/shooting_gallery_hooks.c
@@ -373,3 +373,28 @@ RECOMP_PATCH void EnSyatekiMan_Swamp_SetupGiveReward(EnSyatekiMan* this, PlaySta
         }
     }
 }
+
+void EnSyatekiMan_Swamp_EndGame(EnSyatekiMan* this, PlayState* play);
+
+RECOMP_PATCH void EnSyatekiMan_Swamp_AddBonusPoints(EnSyatekiMan* this, PlayState* play) {
+    static s32 sBonusTimer = 0;
+    Player* player = GET_PLAYER(play);
+
+    player->stateFlags1 |= PLAYER_STATE1_20;
+    if (!play->interfaceCtx.perfectLettersOn) {
+        if (gSaveContext.timerCurTimes[TIMER_ID_MINIGAME_1] == SECONDS_TO_TIMER(0)) {
+            gSaveContext.timerCurTimes[TIMER_ID_MINIGAME_1] = SECONDS_TO_TIMER(0);
+            gSaveContext.timerStates[TIMER_ID_MINIGAME_1] = TIMER_STATE_STOP;
+            this->flagsIndex = 0;
+            this->currentWave = 0;
+            this->actionFunc = EnSyatekiMan_Swamp_EndGame;
+            sBonusTimer = 0;
+        } else {
+            gSaveContext.timerStopTimes[TIMER_ID_MINIGAME_1] += SECONDS_TO_TIMER(1);
+            play->interfaceCtx.minigamePoints += SG_BONUS_POINTS_PER_SECOND;
+            this->score += SG_BONUS_POINTS_PER_SECOND;
+            Actor_PlaySfx(&this->actor, NA_SE_SY_TRE_BOX_APPEAR);
+            sBonusTimer = 0;
+        }
+    }
+}

--- a/src/turtle_hooks.c
+++ b/src/turtle_hooks.c
@@ -1,0 +1,143 @@
+#include "modding.h"
+#include "global.h"
+
+#include "apcommon.h"
+
+struct DmChar08;
+
+typedef void (*DmChar08ActionFunc)(struct DmChar08*, PlayState*);
+
+typedef struct DmChar08 {
+    /* 0x000 */ DynaPolyActor dyna;
+    /* 0x15C */ SkelAnime skelAnime;
+    /* 0x1A0 */ DmChar08ActionFunc actionFunc;
+    /* 0x1A4 */ Actor* palmTree1;
+    /* 0x1A8 */ Actor* palmTree2;
+    /* 0x1AC */ Vec3f tree1Pos;
+    /* 0x1B8 */ Vec3f tree2Pos;
+    /* 0x1C4 */ Vec3f bubblePos;
+    /* 0x1D0 */ Vec3f focusPos;
+    /* 0x1DC */ UNK_TYPE1 unk_1DC[8];
+    /* 0x1E4 */ f32 targetYPos;
+    /* 0x1E8 */ UNK_TYPE1 unk_1E8[8];
+    /* 0x1F0 */ f32 unk_1F0;
+    /* 0x1F4 */ s16 unk_1F4;
+    /* 0x1F6 */ s16 cueId;
+    /* 0x1F6 */ s16 blinkTimer;
+    /* 0x1FA */ s16 unk_1FA;
+    /* 0x1FC */ u16 unk_1FC;
+    /* 0x1FE */ u8 bubbleCount;
+    /* 0x1FF */ u8 unk_1FF;
+    /* 0x200 */ u8 eyeMode;
+    /* 0x201 */ u8 eyeIndex;
+    /* 0x202 */ u8 animIndex;
+    /* 0x203 */ u8 prevAnimIndex;
+    /* 0x204 */ UNK_TYPE1 unk_204;
+    /* 0x205 */ u8 alpha;
+    /* 0x206 */ u8 unk_206;
+    /* 0x207 */ u8 unk_207;
+    /* 0x208 */ u8 unk_208;
+    /* 0x209 */ u8 dynapolyInitialized;
+} DmChar08; // size = 0x20C
+
+#define FLAGS (ACTOR_FLAG_2000000)
+
+#define THIS ((DmChar08*)thisx)
+
+void DmChar08_Init(Actor* thisx, PlayState* play2);
+void DmChar08_Destroy(Actor* thisx, PlayState* play);
+void DmChar08_Update(Actor* thisx, PlayState* play);
+void DmChar08_Draw(Actor* thisx, PlayState* play);
+
+void func_80AAFAC4(DmChar08* this, PlayState* play);
+void DmChar08_WaitForSong(DmChar08* this, PlayState* play);
+void func_80AAF8F4(DmChar08* this, PlayState* play);
+void func_80AAFAE4(DmChar08* this, PlayState* play);
+void DmChar08_DoNothing(DmChar08* this, PlayState* play);
+void func_80AAFA18(DmChar08* this, PlayState* play);
+void DmChar08_SetupAppearCs(DmChar08* this, PlayState* play);
+void func_80AAF884(DmChar08* this, PlayState* play);
+void func_80AAFB04(DmChar08* this, PlayState* play);
+void func_80AAFB94(DmChar08* this, PlayState* play);
+void DmChar08_ChangeAnim(SkelAnime* skelAnime, AnimationInfo* animInfo, u16 animIndex);
+
+typedef enum {
+    /* 0 */ TURTLE_EYEMODE_BLINK_LEFT,
+    /* 1 */ TURTLE_EYEMODE_BLINK_STRAIGHT,
+    /* 2 */ TURTLE_EYEMODE_CLOSED,
+    /* 3 */ TURTLE_EYEMODE_LOOK_STRAIGHT,
+    /* 4 */ TURTLE_EYEMODE_UNUSED,
+    /* 5 */ TURTLE_EYEMODE_LOOK_RIGHT
+} TurtleEyeMode;
+
+extern ActorInit Dm_Char08_InitVars;
+
+typedef enum {
+    /*  0 */ TURTLE_ANIM_IDLE,
+    /*  1 */ TURTLE_ANIM_SWIM,
+    /*  2 */ TURTLE_ANIM_FLOAT,
+    /*  3 */ TURTLE_ANIM_SPEAK1,
+    /*  4 */ TURTLE_ANIM_COUGH,
+    /*  5 */ TURTLE_ANIM_SPEAK2,
+    /*  6 */ TURTLE_ANIM_YAWN,
+    /*  7 */ TURTLE_ANIM_MAX,
+    /* 99 */ TURTLE_ANIM_NONE = 99
+} TurtleAnimation;
+
+extern AnimationHeader gTurtleIdleAnim;
+extern AnimationHeader gTurtleSwimAnim;
+extern AnimationHeader gTurtleFloatAnim;
+extern AnimationHeader gTurtleSpeak1Anim;
+extern AnimationHeader gTurtleCoughAnim;
+extern AnimationHeader gTurtleSpeak2Anim;
+extern AnimationHeader gTurtleYawnAnim;
+extern FlexSkeletonHeader gTurtleSkel;
+extern CollisionHeader gTurtleZoraCapeAwakeCol;
+extern CollisionHeader gTurtleZoraCapeAsleepCol;
+extern CollisionHeader sTurtleGreatBayTempleCol;
+
+static AnimationInfo sAnimationInfo[TURTLE_ANIM_MAX] = {
+    { &gTurtleIdleAnim, 1.0f, 0.0f, -1.0f, ANIMMODE_LOOP, -24.0f },   // TURTLE_ANIM_IDLE
+    { &gTurtleSwimAnim, 1.0f, 0.0f, -1.0f, ANIMMODE_LOOP, -24.0f },   // TURTLE_ANIM_SWIM
+    { &gTurtleFloatAnim, 1.0f, 0.0f, -1.0f, ANIMMODE_LOOP, -24.0f },  // TURTLE_ANIM_FLOAT
+    { &gTurtleSpeak1Anim, 1.0f, 0.0f, -1.0f, ANIMMODE_LOOP, -24.0f }, // TURTLE_ANIM_SPEAK1
+    { &gTurtleCoughAnim, 1.0f, 0.0f, -1.0f, ANIMMODE_LOOP, -24.0f },  // TURTLE_ANIM_COUGH
+    { &gTurtleSpeak2Anim, 1.0f, 0.0f, -1.0f, ANIMMODE_LOOP, -24.0f }, // TURTLE_ANIM_SPEAK2
+    { &gTurtleYawnAnim, 1.0f, 0.0f, -1.0f, ANIMMODE_LOOP, -24.0f },   // TURTLE_ANIM_YAWN
+};
+
+static InitChainEntry sInitChain[] = {
+    ICHAIN_F32(uncullZoneForward, 4000, ICHAIN_CONTINUE),
+    ICHAIN_F32(uncullZoneScale, 4000, ICHAIN_CONTINUE),
+    ICHAIN_F32(uncullZoneDownward, 4000, ICHAIN_STOP),
+};
+
+// TODO: skip the spawning cutscene
+RECOMP_PATCH void DmChar08_SetupAppearCs(DmChar08* this, PlayState* play) {
+    s16 csId = this->dyna.actor.csId;
+    s16 additionalCsId =
+        CutsceneManager_GetAdditionalCsId(CutsceneManager_GetAdditionalCsId(CutsceneManager_GetAdditionalCsId(csId)));
+
+    // if (CHECK_WEEKEVENTREG(WEEKEVENTREG_93_08)) {
+    //     csId = additionalCsId;
+    // }
+    csId = additionalCsId;
+
+    if (CutsceneManager_IsNext(csId)) {
+        CutsceneManager_Start(csId, &this->dyna.actor);
+        SET_WEEKEVENTREG(WEEKEVENTREG_53_20);
+        SET_WEEKEVENTREG(WEEKEVENTREG_93_08);
+        DynaPoly_DeleteBgActor(play, &play->colCtx.dyna, this->dyna.bgId);
+        this->actionFunc = func_80AAF884;
+    } else {
+        CutsceneManager_Queue(csId);
+    }
+}
+
+RECOMP_PATCH void func_80AAFA18(DmChar08* this, PlayState* play) {
+    play->nextEntrance = ENTRANCE(GREAT_BAY_TEMPLE, 0);
+    play->transitionType = TRANS_TYPE_FADE_WHITE_FAST;
+    gSaveContext.nextTransitionType = TRANS_TYPE_FADE_WHITE_FAST;
+    play->transitionTrigger = TRANS_TRIGGER_START;
+    Audio_PlaySfx(NA_SE_SY_WHITE_OUT_T);
+}


### PR DESCRIPTION
Currently skips the following:

- Great Bay Turtle cutscenes
  - Boarding the turtle warps you to Great Bay Temple instantly
  - Spawning him in acts as if he was spawned in a previous cycle
    - He will stay after playing Song of Time
- Swamp Shooting Gallery score countdown time is greatly reduced
- Pierre/Scarecrow now spawns automatically when an ocarina is nearby without needing his song
- Skips Evan's playback cutscenes
- Deku Princess cutscenes
  - She no longer rambles after releasing her from Woodfall Temple
  - She reconciles with the king much quicker
    - You are now warped instantly after the cutscene where you release her in front of the king
- Skips Pirate Fortress Interior "Upper Hookshot Room" monologuing from their leader when approaching the beehive